### PR TITLE
Check data file path

### DIFF
--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -338,7 +338,7 @@ describe('PPOMController', () => {
           'Failed to fetch file with url: https://ppom_cdn_base_url/ppom_version.json',
         );
       });
-      it('should throw error if file path containe weird characters', async () => {
+      it('should throw error if file path contains weird characters', async () => {
         buildFetchSpy({
           status: 200,
           json: () => [

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -265,6 +265,22 @@ describe('PPOMController', () => {
         });
       }).rejects.toThrow('User has not enabled blockaidSecurityCheck');
     });
+
+    it('should throw error if no files are present for the network', async () => {
+      buildFetchSpy({
+        status: 200,
+        json: () => [],
+      });
+      ppomController = buildPPOMController();
+      jest.runOnlyPendingTimers();
+      await expect(async () => {
+        await ppomController.usePPOM(async () => {
+          return Promise.resolve();
+        });
+      }).rejects.toThrow(
+        'Aborting validation as no files are found for the network with chainId: 0x1',
+      );
+    });
   });
 
   describe('updatePPOM', () => {
@@ -315,6 +331,26 @@ describe('PPOMController', () => {
         }).rejects.toThrow(
           'Failed to fetch file with url: https://ppom_cdn_base_url/ppom_version.json',
         );
+      });
+      it('should throw error if file path containe weird characters', async () => {
+        buildFetchSpy({
+          status: 200,
+          json: () => [
+            {
+              name: 'blob',
+              chainId: '0x1',
+              version: '1.0.0',
+              checksum:
+                '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49',
+              filePath: 'test~123$.2*()',
+            },
+          ],
+        });
+        ppomController = buildPPOMController();
+        jest.runOnlyPendingTimers();
+        await expect(async () => {
+          await ppomController.updatePPOM({ updateForAllChains: false });
+        }).rejects.toThrow('Invalid file path for data file: test~123$.2*()');
       });
       it('should throw error if fetch for blob return 500', async () => {
         buildFetchSpy(undefined, {
@@ -498,6 +534,7 @@ describe('PPOMController', () => {
         const chainIdData1 = ppomController.state.chainStatus['0x1'];
         expect(chainIdData1).toBeDefined();
         callBack({ providerConfig: { chainId: '0x2' } });
+        callBack({ providerConfig: { chainId: '0x3' } });
         jest.advanceTimersByTime(NETWORK_CACHE_DURATION);
         jest.runOnlyPendingTimers();
         await flushPromises();
@@ -567,6 +604,39 @@ describe('PPOMController', () => {
         ppomController.state.chainStatus['0x1'].lastVisited;
       expect(chainIdCacheBefore).toStrictEqual(chainIdCacheAfter);
       expect(lastVisitedBefore).toBe(lastVisitedAfter);
+    });
+
+    it('should delete old network if more than 5 networks are added', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2023-01-01'));
+      buildFetchSpy();
+      let callBack: any;
+      ppomController = buildPPOMController({
+        onNetworkChange: (func: any) => {
+          callBack = func;
+        },
+      });
+
+      expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(1);
+
+      jest.useFakeTimers().setSystemTime(new Date('2023-01-02'));
+      callBack({ providerConfig: { chainId: '0x2' } });
+
+      jest.useFakeTimers().setSystemTime(new Date('2023-01-05'));
+      callBack({ providerConfig: { chainId: '0x5' } });
+
+      jest.useFakeTimers().setSystemTime(new Date('2023-01-03'));
+      callBack({ providerConfig: { chainId: '0x3' } });
+
+      jest.useFakeTimers().setSystemTime(new Date('2023-01-04'));
+      callBack({ providerConfig: { chainId: '0x4' } });
+
+      expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(5);
+
+      jest.useFakeTimers().setSystemTime(new Date('2023-01-06'));
+      callBack({ providerConfig: { chainId: '0x6' } });
+      expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(5);
+
+      expect(ppomController.state.chainStatus['0x1']).toBeUndefined();
     });
   });
 

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -283,7 +283,7 @@ export class PPOMController extends BaseControllerV2<
       const chainIds = Object.keys(chainStatus);
       if (chainIds.length >= 5) {
         const oldestChainId = chainIds.sort((c1, c2) =>
-          (chainStatus[c1]?.lastVisited as any) >
+          Number((chainStatus[c1]?.lastVisited) - Number((chainStatus[c2]?.lastVisited)
           (chainStatus[c2]?.lastVisited as any)
             ? -1
             : 1,

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -462,7 +462,12 @@ export class PPOMController extends BaseControllerV2<
     );
   }
 
-  checkFilePath(filePath: string) {
+  /**
+   * The function check to ensure that file path can contain only alphanumeric characters and a dot character (.) or slash (/).
+   *
+   * @param filePath - Path of the file.
+   */
+  #checkFilePath(filePath: string) {
     const filePathRegex = /^[\w./]+$/u;
     if (!filePathRegex.test(filePath)) {
       throw new Error(`Invalid file path for data file: ${filePath}`);
@@ -479,7 +484,7 @@ export class PPOMController extends BaseControllerV2<
     if (this.#checkFilePresentInStorage(storageMetadata, fileVersionInfo)) {
       return;
     }
-    this.checkFilePath(fileVersionInfo.filePath);
+    this.#checkFilePath(fileVersionInfo.filePath);
     const fileUrl = `${URL_PREFIX}${this.#cdnBaseUrl}/${
       fileVersionInfo.filePath
     }`;


### PR DESCRIPTION
The PR has following changes:

1. `usePPOM` throw error if no files are present for the network
2. user can have a minimum of 2 and maximum of 5 networks in `chainStatus`
3. filePath of data files is checked