### PR TITLE
Check for new version info before transaction

### DIFF
--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -348,7 +348,7 @@ describe('PPOMController', () => {
     });
 
     it('should not fail even if local storage files are corrupted and CDN also not return file', async () => {
-      buildFetchSpy();
+      buildFetchSpy(undefined, undefined, 123);
       ppomController = buildPPOMController({
         storageBackend: buildStorageBackend({
           read: async (): Promise<any> => {
@@ -363,9 +363,13 @@ describe('PPOMController', () => {
         return Promise.resolve();
       });
       jest.runOnlyPendingTimers();
-      buildFetchSpy(undefined, {
-        status: 500,
-      });
+      buildFetchSpy(
+        undefined,
+        {
+          status: 500,
+        },
+        123,
+      );
       await expect(async () => {
         await ppomController.usePPOM(async () => {
           return Promise.resolve();
@@ -424,7 +428,7 @@ describe('PPOMController', () => {
       expect(spy).toHaveBeenCalledTimes(10);
     });
     it('should set dataFetched to true for chainId in chainStatus', async () => {
-      buildFetchSpy();
+      buildFetchSpy(undefined, undefined, 123);
       let callBack: any;
       ppomController = buildPPOMController({
         onNetworkChange: (func: any) => {


### PR DESCRIPTION
PR addresses a bug reported by Blockaid team:

- files for a network are downloaded by our scheduled code
- files in CDN are update
- a confirmation to be verified comes: this fails as new files are not available

In the PR I have added code to check (using HEAD request) if new version info file is available before each transaction.


@naugtur : this defies our idea that CDN requests should not be tied to user activity. But I am not able to find a workaround for this.