### PR TITLE
Fix prefixing of hex value on chain id

### DIFF
--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -248,12 +248,13 @@ export class PPOMController extends BaseControllerV2<
     state?: PPOMState;
     blockaidPublicKey: string;
   }) {
+    const currentChainId = addHexPrefix(chainId);
     const initialState = {
       versionInfo: state?.versionInfo ?? [],
       storageMetadata: state?.storageMetadata ?? [],
       chainStatus: state?.chainStatus ?? {
-        [chainId]: {
-          chainId,
+        [currentChainId]: {
+          chainId: currentChainId,
           lastVisited: new Date().getTime(),
           dataFetched: false,
         },
@@ -266,7 +267,7 @@ export class PPOMController extends BaseControllerV2<
       state: initialState,
     });
 
-    this.#chainId = addHexPrefix(chainId);
+    this.#chainId = currentChainId;
     this.#provider = provider;
     this.#ppomProvider = ppomProvider;
     this.#storage = new PPOMStorage({


### PR DESCRIPTION
Related to: https://app.zenhub.com/workspaces/-confirmations-secure-ux-6245e6e2348677001213b8d2/issues/gh/metamask/metamask-planning/1291

Fix the prefixing of hex prefix to chainId.