### PR TITLE
Use controller state to save files instead of indexed db

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,1 @@
 export * from './ppom-controller';
-
-export type { StorageBackend, StorageKey } from './ppom-storage';

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -299,7 +299,6 @@ describe('PPOMController', () => {
     it('should throw error if no files are present for the network', async () => {
       buildFetchSpy();
       jest.spyOn(PPOMStorage, 'readFile' as any).mockImplementation(() => {
-        console.log('Calling Read File');
         throw new Error('File metadata (blob, 0x1) not found');
       });
       ppomController = buildPPOMController();

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -10,8 +10,8 @@ import {
   NETWORK_CACHE_DURATION,
   REFRESH_TIME_INTERVAL,
 } from './ppom-controller';
-import * as Utils from './util';
 import * as PPOMStorage from './ppom-storage';
+import * as Utils from './util';
 
 Object.defineProperty(globalThis, 'crypto', {
   value: {
@@ -637,8 +637,6 @@ describe('PPOMController', () => {
       const freeMock = jest.fn();
       class PPOMClass {
         #jsonRpcRequest: any;
-
-        constructor() {}
 
         new = (jsonRpcRequest: any) => {
           this.#jsonRpcRequest = jsonRpcRequest;

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -792,8 +792,8 @@ export class PPOMController extends BaseControllerV2<
           versionInfo,
           fileStorage,
           updateState: this.#updateState.bind(this),
-        }).catch((exp: Error) => {
-          console.error(`Error in syncing metadata: ${exp.message}`);
+        }).finally(() => {
+          // do nothing, this is so that lint won't complain
         });
       }
     }, scheduleInterval);

--- a/src/ppom-storage.test.ts
+++ b/src/ppom-storage.test.ts
@@ -1,58 +1,73 @@
+import crypto from 'crypto';
+
 import {
   DUMMY_ARRAY_BUFFER_DATA,
-  buildStorageBackend,
-  simpleStorageBackend,
-  storageBackendReturningData,
+  DUMMY_ARRAY_BUFFER_DATA2,
+  DUMMY_ARRAY_BUFFER_DATA_JSON,
+  DUMMY_CHAINID,
+  DUMMY_CHAINID2,
+  DUMMY_CHECKSUM2,
+  DUMMY_NAME,
+  DUMMY_NAME2,
+  VERSION_INFO,
+  getFileData,
 } from '../test/test-utils';
-import { PPOMStorage, StorageKey } from './ppom-storage';
+import { readFile, syncMetadata, writeFile } from './ppom-storage';
 
-const DUMMY_CHECKSUM = 'DUMMY_CHECKSUM';
-const DUMMY_NAME = 'DUMMY_NAME';
-const DUMMY_CHAINID = '1';
-
-const getFileData = (data = {}) => ({
-  chainId: DUMMY_CHAINID,
-  name: DUMMY_NAME,
-  checksum: DUMMY_CHECKSUM,
-  version: '0',
-  ...data,
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    subtle: crypto.webcrypto.subtle,
+  },
 });
 
 const simpleFileData = getFileData();
+const simpleFileData2 = getFileData({
+  chainId: DUMMY_CHAINID2,
+  name: DUMMY_NAME2,
+  checksum: DUMMY_CHECKSUM2,
+  version: '2.0.0',
+});
 
 describe('PPOMStorage', () => {
   describe('readFile', () => {
-    it('should return data', async () => {
-      const ppomStorage = new PPOMStorage({
-        storageBackend: storageBackendReturningData,
-        readMetadata: () => [simpleFileData],
-        writeMetadata: () => undefined,
+    it('should read data', async () => {
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [simpleFileData],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
-      const data = await ppomStorage.readFile(DUMMY_NAME, DUMMY_CHAINID);
+      const data = await readFile(DUMMY_NAME, DUMMY_CHAINID, mockReadState);
       expect(data).toStrictEqual(DUMMY_ARRAY_BUFFER_DATA);
+      expect(mockReadState).toHaveBeenCalledTimes(1);
     });
 
     it('should throw error if file metadata not found', async () => {
-      const ppomStorage = new PPOMStorage({
-        storageBackend: storageBackendReturningData,
-        readMetadata: () => [],
-        writeMetadata: () => undefined,
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
       await expect(async () => {
-        await ppomStorage.readFile(DUMMY_NAME, DUMMY_CHAINID);
+        await readFile(DUMMY_NAME, DUMMY_CHAINID, mockReadState);
       }).rejects.toThrow(
         `File metadata (${DUMMY_NAME}, ${DUMMY_CHAINID}) not found`,
       );
     });
 
     it('should throw error if file is not found in storage', async () => {
-      const ppomStorage = new PPOMStorage({
-        storageBackend: simpleStorageBackend,
-        readMetadata: () => [simpleFileData],
-        writeMetadata: () => undefined,
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [simpleFileData],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
+        },
       });
       await expect(async () => {
-        await ppomStorage.readFile(DUMMY_NAME, DUMMY_CHAINID);
+        await readFile(DUMMY_NAME, DUMMY_CHAINID, mockReadState);
       }).rejects.toThrow(
         `Storage File (${DUMMY_NAME}, ${DUMMY_CHAINID}) not found`,
       );
@@ -60,149 +75,192 @@ describe('PPOMStorage', () => {
   });
 
   describe('writeFile', () => {
-    it('should call storageBackend.write', async () => {
-      const mockWrite = jest.fn().mockResolvedValue('test');
-      const ppomStorage = new PPOMStorage({
-        storageBackend: buildStorageBackend({ write: mockWrite }),
-        readMetadata: () => [],
-        writeMetadata: () => undefined,
+    it('should call write file', async () => {
+      const mockUpdateState = jest.fn().mockResolvedValue(undefined);
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [simpleFileData],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
-      await ppomStorage.writeFile({
+      await writeFile({
         data: DUMMY_ARRAY_BUFFER_DATA,
         ...simpleFileData,
+        readState: mockReadState,
+        updateState: mockUpdateState,
       });
-      expect(mockWrite).toHaveBeenCalledTimes(1);
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(2);
+      expect(mockReadState).toHaveBeenCalledTimes(2);
     });
 
-    it('should invoke writeMetadata if file metadata exists', async () => {
-      const mockWriteMetadata = jest.fn();
-      const ppomStorage = new PPOMStorage({
-        storageBackend: simpleStorageBackend,
-        readMetadata: () => [simpleFileData],
-        writeMetadata: mockWriteMetadata,
+    it('should throw error with wrong checksum', async () => {
+      const mockUpdateState = jest.fn().mockResolvedValue(undefined);
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [simpleFileData],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
-      await ppomStorage.writeFile({
-        data: DUMMY_ARRAY_BUFFER_DATA,
+
+      const withWrongChecksum = {
         ...simpleFileData,
-      });
-      expect(mockWriteMetadata).toHaveBeenCalledWith([simpleFileData]);
+        checksum: DUMMY_CHECKSUM2,
+      };
+
+      await expect(async () => {
+        await writeFile({
+          data: DUMMY_ARRAY_BUFFER_DATA,
+          ...withWrongChecksum,
+          readState: mockReadState,
+          updateState: mockUpdateState,
+        });
+      }).rejects.toThrow(`Checksum mismatch for key blob_0x1`);
     });
 
-    it('should invoke writeMetadata with data passed', async () => {
-      const mockWriteMetadata = jest.fn();
-      const ppomStorage = new PPOMStorage({
-        storageBackend: simpleStorageBackend,
-        readMetadata: () => [],
-        writeMetadata: mockWriteMetadata,
+    it('should call write file with new data', async () => {
+      const mockUpdateState = jest.fn().mockResolvedValue(undefined);
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [simpleFileData],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
-      await ppomStorage.writeFile({
-        data: DUMMY_ARRAY_BUFFER_DATA,
-        ...simpleFileData,
+
+      await writeFile({
+        data: DUMMY_ARRAY_BUFFER_DATA2,
+        ...simpleFileData2,
+        readState: mockReadState,
+        updateState: mockUpdateState,
       });
-      expect(mockWriteMetadata).toHaveBeenCalledWith([simpleFileData]);
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(2);
+      expect(mockReadState).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('syncMetadata', () => {
     it('should return metadata of file if updated file is found in storage', async () => {
-      const mockWriteMetadata = jest.fn();
-      const ppomStorage = new PPOMStorage({
-        storageBackend: storageBackendReturningData,
-        readMetadata: () => [simpleFileData],
-        writeMetadata: mockWriteMetadata,
+      const mockUpdateState = jest.fn().mockResolvedValue(undefined);
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [simpleFileData],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
 
-      const result = await ppomStorage.syncMetadata([simpleFileData]);
-      expect(mockWriteMetadata).toHaveBeenCalledWith([simpleFileData]);
+      const result = await syncMetadata(mockReadState, mockUpdateState);
+
+      expect(mockUpdateState).toHaveBeenCalledWith({
+        storageMetadata: [simpleFileData],
+      });
+      expect(mockUpdateState).toHaveBeenCalledTimes(1);
+      expect(mockReadState).toHaveBeenCalledTimes(2);
       expect(result).toStrictEqual([simpleFileData]);
     });
 
     it('should not return data if file is not found in storage', async () => {
-      const mockWriteMetadata = jest.fn();
-      const ppomStorage = new PPOMStorage({
-        storageBackend: simpleStorageBackend,
-        readMetadata: () => [simpleFileData],
-        writeMetadata: mockWriteMetadata,
+      const mockUpdateState = jest.fn().mockResolvedValue(undefined);
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [simpleFileData],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
+        },
       });
 
-      const result = await ppomStorage.syncMetadata([simpleFileData]);
-      expect(mockWriteMetadata).toHaveBeenCalledWith([]);
+      const result = await syncMetadata(mockReadState, mockUpdateState);
+
+      expect(mockUpdateState).toHaveBeenCalledWith({
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
+        },
+      });
+      expect(mockUpdateState).toHaveBeenCalledWith({
+        storageMetadata: [],
+      });
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(2);
+      expect(mockReadState).toHaveBeenCalledTimes(2);
       expect(result).toStrictEqual([]);
     });
 
     it('should not return metadata of file if file version in storage is outdated', async () => {
-      const storageFileData = { ...simpleFileData, version: '1' };
-      const mockWriteMetadata = jest.fn();
-      const mockDelete = jest.fn().mockResolvedValue('');
-
-      const ppomStorage = new PPOMStorage({
-        storageBackend: buildStorageBackend({
-          read: async (_key: StorageKey): Promise<any> =>
-            Promise.resolve(DUMMY_ARRAY_BUFFER_DATA),
-          dir: async () => Promise.resolve([storageFileData]),
-          delete: mockDelete,
+      const mockUpdateState = jest.fn().mockResolvedValue(undefined);
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [simpleFileData],
+        versionInfo: VERSION_INFO.map((versionInfo) => {
+          return {
+            ...versionInfo,
+            version: '1',
+          };
         }),
-        readMetadata: () => [simpleFileData],
-        writeMetadata: mockWriteMetadata,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
 
-      const result = await ppomStorage.syncMetadata([storageFileData]);
-      expect(mockDelete).toHaveBeenCalledWith({
-        name: DUMMY_NAME,
-        chainId: DUMMY_CHAINID,
+      const result = await syncMetadata(mockReadState, mockUpdateState);
+
+      expect(mockUpdateState).toHaveBeenCalledWith({
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
+        },
       });
-      expect(mockWriteMetadata).toHaveBeenCalledWith([]);
+      expect(mockUpdateState).toHaveBeenCalledWith({
+        storageMetadata: [],
+      });
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(2);
+      expect(mockReadState).toHaveBeenCalledTimes(2);
+
       expect(result).toStrictEqual([]);
     });
 
     it('should delete file from storage backend if its name is not found in file version info passed', async () => {
-      const fileDataInStorage = getFileData({
-        name: 'dummy_2',
-      });
-      const mockWriteMetadata = jest.fn();
-      const mockDelete = jest.fn().mockResolvedValue('');
-
-      const ppomStorage = new PPOMStorage({
-        storageBackend: buildStorageBackend({
-          read: async (_key: StorageKey): Promise<any> =>
-            Promise.resolve(DUMMY_ARRAY_BUFFER_DATA),
-          dir: async () => Promise.resolve([fileDataInStorage]),
-          delete: mockDelete,
-        }),
-        readMetadata: () => [simpleFileData],
-        writeMetadata: mockWriteMetadata,
+      const mockUpdateState = jest.fn().mockResolvedValue(undefined);
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [{ ...simpleFileData, name: 'dummy_2' }],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
 
-      await ppomStorage.syncMetadata([simpleFileData]);
-      expect(mockDelete).toHaveBeenCalledWith({
-        name: 'dummy_2',
-        chainId: DUMMY_CHAINID,
+      const result = await syncMetadata(mockReadState, mockUpdateState);
+
+      expect(mockUpdateState).toHaveBeenCalledWith({
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
+        },
       });
+      expect(mockUpdateState).toHaveBeenCalledWith({
+        storageMetadata: [],
+      });
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(2);
+      expect(mockReadState).toHaveBeenCalledTimes(2);
+      expect(result).toStrictEqual([]);
     });
 
     it('should delete file from storage backend if its version info is not passed', async () => {
-      const fileDataInStorage = getFileData({
-        chainId: '5',
-      });
-      const mockWriteMetadata = jest.fn();
-      const mockDelete = jest.fn().mockResolvedValue('');
-
-      const ppomStorage = new PPOMStorage({
-        storageBackend: buildStorageBackend({
-          read: async (_key: StorageKey): Promise<any> =>
-            Promise.resolve(DUMMY_ARRAY_BUFFER_DATA),
-          dir: async () => Promise.resolve([fileDataInStorage]),
-          delete: mockDelete,
-        }),
-        readMetadata: () => [simpleFileData],
-        writeMetadata: mockWriteMetadata,
+      const mockUpdateState = jest.fn().mockResolvedValue(undefined);
+      const mockReadState = jest.fn().mockReturnValue({
+        storageMetadata: [{ ...simpleFileData, version: undefined }],
+        versionInfo: VERSION_INFO,
+        fileStorage: {
+          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
+        },
       });
 
-      await ppomStorage.syncMetadata([simpleFileData]);
-      expect(mockDelete).toHaveBeenCalledWith({
-        name: DUMMY_NAME,
-        chainId: '5',
-      });
+      const result = await syncMetadata(mockReadState, mockUpdateState);
+      expect(mockUpdateState).toHaveBeenCalledTimes(2);
+      expect(mockReadState).toHaveBeenCalledTimes(2);
+      expect(result).toStrictEqual([]);
     });
   });
 });

--- a/src/ppom-storage.test.ts
+++ b/src/ppom-storage.test.ts
@@ -48,13 +48,6 @@ describe('PPOMStorage', () => {
     });
 
     it('should throw error if file metadata not found', async () => {
-      const mockReadState = jest.fn().mockReturnValue({
-        storageMetadata: [],
-        versionInfo: VERSION_INFO,
-        fileStorage: {
-          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: DUMMY_ARRAY_BUFFER_DATA_JSON,
-        },
-      });
       await expect(async () => {
         await readFile({
           name: DUMMY_NAME,
@@ -70,13 +63,6 @@ describe('PPOMStorage', () => {
     });
 
     it('should throw error if file is not found in storage', async () => {
-      const mockReadState = jest.fn().mockReturnValue({
-        storageMetadata: [simpleFileData],
-        versionInfo: VERSION_INFO,
-        fileStorage: {
-          [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
-        },
-      });
       await expect(async () => {
         await readFile({
           name: DUMMY_NAME,
@@ -163,40 +149,6 @@ describe('PPOMStorage', () => {
       expect(mockUpdateState).toHaveBeenCalledTimes(1);
       expect(result).toStrictEqual([simpleFileData]);
     });
-
-    // it('should not return data if file is not found in storage', async () => {
-    //   const mockUpdateState = jest.fn().mockResolvedValue(undefined);
-    //   const mockReadState = jest.fn().mockReturnValue({
-    //     storageMetadata: [simpleFileData],
-    //     versionInfo: VERSION_INFO,
-    //     fileStorage: {
-    //       [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
-    //     },
-    //   });
-
-    //   const result = await syncMetadata({
-    //     storageMetadata: [simpleFileData],
-    //     versionInfo: VERSION_INFO,
-    //     fileStorage: {
-    //       [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
-    //     },
-    //     readState: mockReadState,
-    //     updateState: mockUpdateState,
-    //   });
-
-    //   expect(mockUpdateState).toHaveBeenCalledWith({
-    //     fileStorage: {
-    //       [`${DUMMY_NAME}_${DUMMY_CHAINID}`]: undefined,
-    //     },
-    //   });
-    //   expect(mockUpdateState).toHaveBeenCalledWith({
-    //     storageMetadata: [],
-    //   });
-
-    //   expect(mockUpdateState).toHaveBeenCalledTimes(2);
-    //   expect(mockReadState).toHaveBeenCalledTimes(1);
-    //   expect(result).toStrictEqual([]);
-    // });
 
     it('should not return metadata of file if file version in storage is outdated', async () => {
       const mockUpdateState = jest.fn().mockResolvedValue(undefined);

--- a/src/ppom-storage.ts
+++ b/src/ppom-storage.ts
@@ -96,12 +96,11 @@ const jsonStringToArrayBuffer = (json: string | undefined) => {
  * 2. Check if the file exists in the metadata.
  *
  * @param options - Object passed to read file.
- * @param options.name - name of the file.
- * @param options.chainId - chainId of the file.
+ * @param options.name - Name of the file.
+ * @param options.chainId - ChainId of the file.
  * @param options.fileStorage - File data saved in state.
  * @param options.storageMetadata - Metadata about files saved in storage.
  * @returns ArrayBuffer of file data.
- * @throws Exception if file is not found or checksum can not be validated.
  */
 export const readFile = async ({
   name,
@@ -121,7 +120,7 @@ export const readFile = async ({
     throw new Error(`File metadata (${name}, ${chainId}) not found`);
   }
 
-  const stateFileStorage = fileStorage as Record<string, string>;
+  const stateFileStorage = fileStorage;
 
   const data = jsonStringToArrayBuffer(stateFileStorage[`${name}_${chainId}`]);
 

--- a/src/ppom-storage.ts
+++ b/src/ppom-storage.ts
@@ -1,3 +1,5 @@
+import { PPOMState } from './ppom-controller';
+
 /**
  * @type FileMetadata
  * Defined type for information about file saved in storage backend.
@@ -22,7 +24,7 @@ export type FileMetadataList = FileMetadata[];
 
 /**
  * @type StorageKey
- * This defines type of key that is used for indexing file data saved in StorageBackend.
+ * This defines type of key that is used for indexing file data saved in State.
  * @property name - Name of the file.
  * @property chainId - ChainId for file.
  */
@@ -32,81 +34,128 @@ export type StorageKey = {
 };
 
 /**
- * @type StorageBackend
- * This defines type for storage backend implementation.
- * There will be different storage implementations depending on platform:
- * 1. extension - indexDB
- * 2. mobile app - <TBD>
- * @property read - Read file from storage.
- * @property write - Write file to storage.
- * @property delete - Delete file from storage.
- * @property dir - Get list of all files in storage.
+ * Validates data against a checksum.
+ *
+ * @param key - Key object containing the name and chainId of file.
+ * @param checksum - Checksum to use in validation.
+ * @param data - Data to validate.
+ * @throws Exception is checksum can not be validated
  */
-export type StorageBackend = {
-  read(key: StorageKey, checksum: string): Promise<ArrayBuffer>;
-  write(key: StorageKey, data: ArrayBuffer, checksum: string): Promise<void>;
-  delete(key: StorageKey): Promise<void>;
-  dir(): Promise<StorageKey[]>;
+const validateChecksum = async (
+  key: StorageKey,
+  checksum: string,
+  data: ArrayBuffer | undefined,
+) => {
+  if (data) {
+    // eslint-disable-next-line no-restricted-globals
+    const hash = await crypto.subtle.digest('SHA-256', data);
+    const hashString = Array.from(new Uint8Array(hash))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+
+    if (hashString !== checksum) {
+      throw new Error(`Checksum mismatch for key ${key.name}_${key.chainId}`);
+    }
+  } else {
+    throw new Error(`Storage File (${key.name}, ${key.chainId}) not found`);
+  }
 };
 
 /**
- * @class PPOMStorage
- * This class is responsible for managing the local storage
- * It provides the following functionalities:
- * 1. Sync the metadata with the version info from the cdn
- * 2. Read a file from the local storage
- * 3. Write a file to the local storage
+ * Converts ArrayBuffer to json string.
  *
- * It also validates the checksum of the file when reading and writing in order to
- * detect corrupted files or files that are not up to date
+ * @param data - Data to convert to json string.
+ * @returns JSON string of converted ArrayBuffer data.
  */
-export class PPOMStorage {
-  readonly #storageBackend: StorageBackend;
+export const arrayBufferToJson = (data: ArrayBuffer) => {
+  const dataToUintArray = new Uint8Array(data);
+  const stringFromCharCode = String.fromCharCode(...dataToUintArray);
+  return stringFromCharCode;
+};
 
-  readonly #readMetadata: () => FileMetadataList;
-
-  readonly #writeMetadata: (metadata: FileMetadataList) => void;
-
-  /**
-   * Creates a PPOMStorage instance.
-   *
-   * @param options - The options passed to the function.
-   * @param options.storageBackend - The storage backend to use for the local storage.
-   * @param options.readMetadata - A function to read the metadata from the local storage.
-   * @param options.writeMetadata - A function to write the metadata to the local storage.
-   */
-  constructor({
-    storageBackend,
-    readMetadata,
-    writeMetadata,
-  }: {
-    storageBackend: StorageBackend;
-    readMetadata: () => FileMetadataList;
-    writeMetadata: (metadata: FileMetadataList) => void;
-  }) {
-    this.#storageBackend = storageBackend;
-    this.#readMetadata = readMetadata;
-    this.#writeMetadata = writeMetadata;
+/**
+ * Converts json string to array buffer.
+ *
+ * @param json - JSON string to convert to ArrayBuffer.
+ * @returns ArrayBuffer of convered data.
+ */
+const jsonStringToArrayBuffer = (json: string | undefined) => {
+  if (json) {
+    const dataToUintArray = new Uint8Array(
+      [...json].map((character) => character.charCodeAt(0)),
+    );
+    return dataToUintArray.buffer;
   }
 
-  /**
-   * Sync the metadata with the version info from the cdn.
-   * 1. Remove the files that are not readable (e.g. corrupted or deleted).
-   * 2. Remove the files that are not in the cdn anymore.
-   * 3. Remove the files that are not up to date in the cdn.
-   * 4. Remove the files that are not in the local storage from the metadata.
-   * 5. Delete the files that are not in the metadata from the local storage.
-   *
-   * @param versionInfo - Version information of metadata files.
-   */
-  async syncMetadata(versionInfo: FileMetadataList): Promise<FileMetadataList> {
-    const metadata = this.#readMetadata();
-    const syncedMetadata: FileMetadataList = [];
+  return undefined;
+};
 
-    for (const fileMetadata of metadata) {
+/**
+ * Read the file from the local storage.
+ * 1. Check if the file exists in the local storage.
+ * 2. Check if the file exists in the metadata.
+ *
+ * @param name - Name assigned to storage.
+ * @param chainId - ChainId for which file is queried.
+ * @param readState - Controller read state function.
+ */
+export const readFile = async (
+  name: string,
+  chainId: string,
+  readState: (key?: keyof PPOMState) => Partial<PPOMState>,
+): Promise<ArrayBuffer> => {
+  const { storageMetadata, fileStorage } = readState();
+
+  const fileMetadata = storageMetadata?.find(
+    (file: any) => file.name === name && file.chainId === chainId,
+  );
+  if (!fileMetadata) {
+    throw new Error(`File metadata (${name}, ${chainId}) not found`);
+  }
+
+  const stateFileStorage = fileStorage as Record<string, string>;
+
+  const data = jsonStringToArrayBuffer(stateFileStorage[`${name}_${chainId}`]);
+
+  await validateChecksum(
+    {
+      name,
+      chainId,
+    },
+    fileMetadata.checksum,
+    data,
+  );
+
+  return data as ArrayBuffer;
+};
+
+/**
+ * Sync the metadata with the version info from the cdn.
+ * 1. Remove the files that are not readable (e.g. corrupted or deleted).
+ * 2. Remove the files that are not in the cdn anymore.
+ * 3. Remove the files that are not up to date in the cdn.
+ * 4. Remove the files that are not in the local storage from the metadata.
+ * 5. Delete the files that are not in the metadata from the local storage.
+ *
+ * @param readState - Controller read state function.
+ * @param updateState - Controller update state function.
+ * @returns The metadata after it was synchronized.
+ */
+export const syncMetadata = async (
+  readState: (key?: keyof PPOMState) => Partial<PPOMState>,
+  updateState: (newState: Partial<PPOMState>) => void,
+): Promise<FileMetadataList> => {
+  const { storageMetadata, versionInfo, fileStorage } = readState();
+
+  const stateFileStorage = fileStorage as Record<string, string>;
+
+  const syncedMetadata: FileMetadataList = [];
+
+  if (storageMetadata) {
+    for (const fileMetadata of storageMetadata) {
       // check if the file is readable (e.g. corrupted or deleted)
       try {
-        await this.readFile(fileMetadata.name, fileMetadata.chainId);
+        await readFile(fileMetadata.name, fileMetadata.chainId, readState);
       } catch (exp: any) {
         console.error('Error: ', exp);
         continue;
@@ -114,7 +163,7 @@ export class PPOMStorage {
 
       // check if the file exits and up to date in the storage
       if (
-        !versionInfo.find(
+        !versionInfo?.find(
           (file) =>
             file.name === fileMetadata.name &&
             file.chainId === fileMetadata.chainId &&
@@ -127,80 +176,98 @@ export class PPOMStorage {
 
       syncedMetadata.push(fileMetadata);
     }
+  }
 
-    const filesInDB = await this.#storageBackend.dir();
-    for (const { name, chainId } of filesInDB) {
-      if (
-        !syncedMetadata.find(
-          (file) => file.name === name && file.chainId === chainId,
-        )
-      ) {
-        await this.#storageBackend.delete({ name, chainId });
+  const filesInState = Object.keys(stateFileStorage).map((key) => {
+    const [name, chainId] = key.split('_');
+    return { name, chainId };
+  });
+
+  for (const { name, chainId } of filesInState) {
+    if (
+      !syncedMetadata.find(
+        (file) => file.name === name && file.chainId === chainId,
+      )
+    ) {
+      if (fileStorage) {
+        delete fileStorage[`${name as string}_${chainId as string}`];
       }
-    }
 
-    this.#writeMetadata(syncedMetadata);
-    return syncedMetadata;
+      updateState({
+        fileStorage: {
+          ...fileStorage,
+        },
+      });
+    }
   }
 
-  /**
-   * Read the file from the local storage.
-   * 1. Check if the file exists in the local storage.
-   * 2. Check if the file exists in the metadata.
-   *
-   * @param name - Name assigned to storage.
-   * @param chainId - ChainId for which file is queried.
-   */
-  async readFile(name: string, chainId: string): Promise<ArrayBuffer> {
-    const metadata = this.#readMetadata();
-    const fileMetadata = metadata.find(
-      (file) => file.name === name && file.chainId === chainId,
-    );
-    if (!fileMetadata) {
-      throw new Error(`File metadata (${name}, ${chainId}) not found`);
-    }
+  updateState({
+    storageMetadata: [...syncedMetadata],
+  });
 
-    const data = await this.#storageBackend.read(
-      { name, chainId },
-      fileMetadata.checksum,
-    );
-    if (!data) {
-      throw new Error(`Storage File (${name}, ${chainId}) not found`);
-    }
+  return syncedMetadata;
+};
 
-    return data;
-  }
-
-  /**
-   * Write the file to the local storage.
-   * 1. Write the file to the local storage.
-   * 2. Update the metadata.
-   *
-   * @param options - Object passed to write to storage.
-   * @param options.data - File data to be written.
-   * @param options.name - Name to be assigned to the storage.
-   * @param options.chainId - Current ChainId.
-   * @param options.version - Version of file.
-   * @param options.checksum - Checksum of file.
-   */
-  async writeFile({
-    data,
-    name,
-    chainId,
-    version,
+/**
+ * Write the file to the local storage.
+ * 1. Write the file to the local storage.
+ * 2. Update the metadata.
+ *
+ * @param options - Object passed to write to storage.
+ * @param options.data - File data to be written.
+ * @param options.name - Name to be assigned to the storage.
+ * @param options.chainId - Current ChainId.
+ * @param options.version - Version of file.
+ * @param options.checksum - Checksum of file.
+ * @param options.readState - Controller read state function.
+ * @param options.updateState - Controller function to update state.
+ */
+export const writeFile = async ({
+  data,
+  name,
+  chainId,
+  version,
+  checksum,
+  readState,
+  updateState,
+}: {
+  data: ArrayBuffer;
+  name: string;
+  chainId: string;
+  version: string;
+  checksum: string;
+  readState: (key?: keyof PPOMState) => Partial<PPOMState>;
+  updateState: (newState: Partial<PPOMState>) => void;
+}) => {
+  await validateChecksum(
+    {
+      name,
+      chainId,
+    },
     checksum,
-  }: {
-    data: ArrayBuffer;
-    name: string;
-    chainId: string;
-    version: string;
-    checksum: string;
-  }): Promise<void> {
-    await this.#storageBackend.write({ name, chainId }, data, checksum);
+    data,
+  );
 
-    const metadata = this.#readMetadata();
+  const { fileStorage } = readState('fileStorage');
+
+  const draftFile = arrayBufferToJson(data);
+
+  if (draftFile) {
+    updateState({
+      fileStorage: {
+        ...fileStorage,
+        [`${name}_${chainId}`]: draftFile,
+      },
+    });
+  }
+
+  const { storageMetadata } = readState('storageMetadata');
+
+  const metadata = storageMetadata as FileMetadataList;
+
+  if (metadata) {
     const fileMetadata = metadata.find(
-      (file) => file.name === name && file.chainId === chainId,
+      (file: any) => file.name === name && file.chainId === chainId,
     );
 
     if (fileMetadata) {
@@ -210,6 +277,8 @@ export class PPOMStorage {
       metadata.push({ name, chainId, version, checksum });
     }
 
-    this.#writeMetadata(metadata);
+    updateState({
+      storageMetadata: [...metadata],
+    });
   }
-}
+};

--- a/src/ppom-storage.ts
+++ b/src/ppom-storage.ts
@@ -236,6 +236,8 @@ export const syncMetadata = async ({
  * @param options - Object passed to write to storage.
  * @param options.data - File data to be written.
  * @param options.fileVersionInfo - File Metadata with version information.
+ * @param options.fileStorage - File data saved in state.
+ * @param options.storageMetadata - Metadata about files saved in storage.
  * @param options.updateState - Controller function to update state.
  */
 export const writeFile = async ({

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -54,7 +54,7 @@ export const DUMMY_CHECKSUM2 =
 export const VERSION_INFO = [
   {
     name: DUMMY_NAME,
-    chainId: '0x1',
+    chainId: DUMMY_CHAINID,
     version: '1.0.0',
     checksum:
       '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49',
@@ -64,7 +64,7 @@ export const VERSION_INFO = [
   },
   {
     name: DUMMY_DATANAME,
-    chainId: '0x1',
+    chainId: DUMMY_CHAINID,
     version: '1.0.3',
     checksum:
       '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49',

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -2,7 +2,7 @@ import { ControllerMessenger } from '@metamask/base-controller';
 import * as ControllerUtils from '@metamask/controller-utils';
 
 import { PPOMController } from '../src/ppom-controller';
-import { StorageKey } from '../src/ppom-storage';
+import { StorageKey, arrayBufferToJson } from '../src/ppom-storage';
 
 export const buildDummyResponse = (
   resultType = 'DUMMY_RESULT_TYPE',
@@ -31,32 +31,46 @@ export const buildStorageBackend = (obj = {}) => {
 export const simpleStorageBackend = buildStorageBackend();
 
 export const DUMMY_ARRAY_BUFFER_DATA = new ArrayBuffer(123);
+export const DUMMY_ARRAY_BUFFER_DATA2 = new ArrayBuffer(234);
+export const DUMMY_ARRAY_BUFFER_DATA_JSON = arrayBufferToJson(
+  DUMMY_ARRAY_BUFFER_DATA,
+);
 
-export const storageBackendReturningData = buildStorageBackend({
-  read: async (_key: StorageKey): Promise<any> =>
-    Promise.resolve(DUMMY_ARRAY_BUFFER_DATA),
-});
+export const DUMMY_ARRAY_BUFFER_DATA_JSON2 = arrayBufferToJson(
+  DUMMY_ARRAY_BUFFER_DATA2,
+);
+
+export const DUMMY_NAME = 'blob';
+export const DUMMY_NAME2 = 'blob2';
+export const DUMMY_DATANAME = 'data';
+export const DUMMY_CHAINID = '0x1';
+export const DUMMY_CHAINID2 = '0x2';
+
+const DUMMY_CHECKSUM =
+  '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49';
+export const DUMMY_CHECKSUM2 =
+  '0479688f99e8cbc70291ce272876ff8e0db71a0889daf2752884b0996056b4a0';
 
 export const VERSION_INFO = [
   {
-    name: 'blob',
+    name: DUMMY_NAME,
     chainId: '0x1',
     version: '1.0.0',
     checksum:
       '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49',
     signature:
       '0x304402206d433e9172960de6717d94ae263e47eefacd3584a3274a452f8f9567b3a797db02201b2e423188fb3f9daa6ce6a8723f69df26bd3ceeee81f77250526b91e093614f',
-    filePath: 'blob',
+    filePath: DUMMY_NAME,
   },
   {
-    name: 'data',
+    name: DUMMY_DATANAME,
     chainId: '0x1',
     version: '1.0.3',
     checksum:
       '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49',
     signature:
       '0x304402206d433e9172960de6717d94ae263e47eefacd3584a3274a452f8f9567b3a797db02201b2e423188fb3f9daa6ce6a8723f69df26bd3ceeee81f77250526b91e093614f',
-    filePath: 'data',
+    filePath: DUMMY_DATANAME,
   },
 ];
 
@@ -148,10 +162,17 @@ class PPOMClass {
   };
 }
 
+export const getFileData = (data = {}) => ({
+  chainId: DUMMY_CHAINID,
+  name: DUMMY_NAME,
+  checksum: DUMMY_CHECKSUM,
+  version: '1.0.0',
+  ...data,
+});
+
 export const buildPPOMController = (args?: any) => {
   const controllerMessenger = new ControllerMessenger();
   const ppomController = new PPOMController({
-    storageBackend: storageBackendReturningData,
     provider: () => undefined,
     chainId: '0x1',
     onNetworkChange: () => undefined,


### PR DESCRIPTION
This PR include the following changes

1. Use the controller state to store PPOM files instead of passing in a storageBackend to the constructor
2. Remove the reliance on storageBackend 
3. Make ppomStorage a utils file instead of a file that exposes methods to sync metadata, read files and write files.
4. Unit tests for the above.
* Fixes [#729](https://github.com/MetaMask/MetaMask-planning/issues/729)
