### PR TITLE
Fix syncing file metadata

### DIFF
--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -472,7 +472,6 @@ export class PPOMController extends BaseControllerV2<
   async #updatePPOM(): Promise<void> {
     const versionInfoUpdated = await this.#updateVersionInfo();
     if (versionInfoUpdated) {
-      await this.#storage.syncMetadata(this.state.versionInfo);
       await this.#getNewFilesForAllChains();
     }
   }
@@ -743,6 +742,8 @@ export class PPOMController extends BaseControllerV2<
       // clear interval if all files are fetched
       if (!fileToBeFetchedList.length) {
         clearInterval(this.#fileScheduleInterval);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.#storage.syncMetadata(this.state.versionInfo);
       }
     }, scheduleInterval);
   }
@@ -934,8 +935,8 @@ export class PPOMController extends BaseControllerV2<
    * Functioned to be called to update PPOM.
    */
   #onDataUpdateDuration(): void {
-    this.updatePPOM().catch(() => {
-      // console.error(`Error while trying to update PPOM: ${exp.message}`);
+    this.updatePPOM().catch((exp: Error) => {
+      console.error(`Error while trying to update PPOM: ${exp.message}`);
     });
   }
 


### PR DESCRIPTION
Fix call to sync metadata, this should be done only after all files are downloaded.

Partially addresses: https://app.zenhub.com/workspaces/-confirmations-secure-ux-6245e6e2348677001213b8d2/issues/gh/metamask/metamask-planning/1458