### PR TITLE
Create copy of providerRequestsCount object before returning

### DIFF
--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -388,7 +388,12 @@ export class PPOMController extends BaseControllerV2<
       this.#providerRequestsCount = {};
       const result = await callback(this.#ppom);
 
-      return { ...result, providerRequestsCount: this.#providerRequestsCount };
+      return {
+        ...result,
+        // we are destructuring the object below as this will be used outside the controller
+        // we want to avoid possibility of outside code changing an inctance variable.
+        providerRequestsCount: { ...this.#providerRequestsCount },
+      };
     });
   }
 

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -391,7 +391,7 @@ export class PPOMController extends BaseControllerV2<
       return {
         ...result,
         // we are destructuring the object below as this will be used outside the controller
-        // we want to avoid possibility of outside code changing an inctance variable.
+        // we want to avoid possibility of outside code changing an instance variable.
         providerRequestsCount: { ...this.#providerRequestsCount },
       };
     });


### PR DESCRIPTION
Fixes: MetaMask/metamask-extension#21486

We should copy `this.#providerRequestsCount` before sending it back in result.