### PR TITLE
Async initialization on ppom after PPOMController is constructed

### DIFF
--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -1,4 +1,5 @@
 import {
+  PPOMClass,
   VERSION_INFO,
   buildDummyResponse,
   buildFetchSpy,
@@ -16,6 +17,18 @@ jest.mock('@metamask/controller-utils', () => {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __esModule: true,
     ...jest.requireActual('@metamask/controller-utils'),
+  };
+});
+
+jest.mock('await-semaphore', () => {
+  class Mutex {
+    use(callback: any) {
+      return callback();
+    }
+  }
+  return {
+    ...jest.requireActual('await-semaphore'),
+    Mutex,
   };
 });
 
@@ -52,7 +65,7 @@ describe('PPOMController', () => {
       const spy = buildFetchSpy(undefined, undefined, 123);
       ppomController = buildPPOMController();
 
-      expect(spy).toHaveBeenCalledTimes(0);
+      expect(spy).toHaveBeenCalledTimes(1);
       jest.runAllTicks();
       await flushPromises();
       expect(spy).toHaveBeenCalledTimes(2);
@@ -71,7 +84,7 @@ describe('PPOMController', () => {
       expect(spy).toHaveBeenCalledTimes(6);
     });
 
-    it('should not fail if there is error in initializing PPOM', async () => {
+    it('should create instance of PPOMController even if there is an error in initialising PPOM', async () => {
       buildFetchSpy();
       ppomController = buildPPOMController({
         ppomProvider: {
@@ -92,6 +105,7 @@ describe('PPOMController', () => {
       buildFetchSpy();
       ppomController = buildPPOMController();
       jest.runOnlyPendingTimers();
+      await flushPromises();
 
       await ppomController.usePPOM(async (ppom: any) => {
         expect(ppom).toBeDefined();
@@ -103,6 +117,7 @@ describe('PPOMController', () => {
       buildFetchSpy();
       ppomController = buildPPOMController();
       jest.runOnlyPendingTimers();
+      await flushPromises();
 
       const result = await ppomController.usePPOM(async (ppom: any) => {
         expect(ppom).toBeDefined();
@@ -111,7 +126,7 @@ describe('PPOMController', () => {
       expect(result).toStrictEqual(dummyResponse);
     });
 
-    it('should fetch data for files in version info other than mainnet', async () => {
+    it('should not fetch files for network not supported for PPOM validations', async () => {
       const spy = buildFetchSpy(
         {
           status: 200,
@@ -133,13 +148,13 @@ describe('PPOMController', () => {
       ppomController = buildPPOMController({
         fileFetchScheduleDuration: 0,
       });
+      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL + 1);
+      await flushPromises();
 
-      jest.runOnlyPendingTimers();
-      const result = await ppomController.usePPOM(async (ppom: any) => {
+      await ppomController.usePPOM(async (ppom: any) => {
         expect(ppom).toBeDefined();
-        return Promise.resolve(buildDummyResponse());
+        return Promise.resolve();
       });
-      expect(result).toStrictEqual(dummyResponse);
       expect(spy).toHaveBeenCalledTimes(5);
     });
 
@@ -153,111 +168,12 @@ describe('PPOMController', () => {
         },
       });
       jest.runOnlyPendingTimers();
+      await flushPromises();
 
       await ppomController.usePPOM(async (ppom: any) => {
         const result = await ppom.testJsonRPCRequest();
         expect(result).toBe('DUMMY_VALUE');
       });
-    });
-
-    it('should propogate to ppom if JSON RPC request on provider fails', async () => {
-      buildFetchSpy();
-      ppomController = buildPPOMController({
-        provider: {
-          sendAsync: (_arg1: any, arg2: any) => {
-            arg2('DUMMY_ERROR');
-          },
-        },
-      });
-      jest.runOnlyPendingTimers();
-      await ppomController.usePPOM(async (ppom: any) => {
-        ppom.testJsonRPCRequest().catch((exp: any) => {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(exp).toBe('DUMMY_ERROR');
-        });
-      });
-    });
-
-    it('should throw error if method call on provider is not allowed to PPOM', async () => {
-      buildFetchSpy();
-      ppomController = buildPPOMController({
-        provider: {
-          sendAsync: (_arg1: any, arg2: any) => {
-            arg2('DUMMY_ERROR');
-          },
-        },
-      });
-      jest.runOnlyPendingTimers();
-      await ppomController.usePPOM(async (ppom: any) => {
-        ppom.testJsonRPCRequest('DUMMY_METHOD').catch((exp: any) => {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(exp.error.message).toBe('Method not supported');
-        });
-      });
-    });
-
-    it('should rate limit number of requests by PPOM on provider', async () => {
-      buildFetchSpy();
-      ppomController = buildPPOMController({
-        provider: {
-          sendAsync: (_arg1: any, arg2: any) => {
-            arg2(undefined, 'DUMMY_VALUE');
-          },
-        },
-        providerRequestLimit: 5,
-      });
-      jest.runOnlyPendingTimers();
-
-      await ppomController.usePPOM(async (ppom: any) => {
-        await ppom.testJsonRPCRequest();
-        await ppom.testJsonRPCRequest();
-        await ppom.testJsonRPCRequest();
-        await ppom.testJsonRPCRequest();
-        await ppom.testJsonRPCRequest();
-        await ppom.testJsonRPCRequest();
-        const result = await ppom.testJsonRPCRequest().catch((exp: any) => {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(exp.error.message).toBe('Limit exceeded');
-        });
-        expect(result.error.code).toBe(
-          Utils.PROVIDER_ERRORS.limitExceeded().error.code,
-        );
-      });
-    });
-
-    it('should record number of times each RPC method is called and return it in response', async () => {
-      buildFetchSpy();
-      ppomController = buildPPOMController({
-        provider: {
-          sendAsync: (_arg1: any, arg2: any) => {
-            arg2(undefined, 'DUMMY_VALUE');
-          },
-        },
-        providerRequestLimit: 25,
-      });
-      jest.runOnlyPendingTimers();
-
-      const result = await ppomController.usePPOM(async (ppom: any) => {
-        await ppom.testCallRpcRequests();
-        return Promise.resolve(buildDummyResponse());
-      });
-
-      const providerRequestsCount = {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        eth_getBalance: 1,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        eth_getTransactionCount: 2,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        trace_call: 3,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        trace_callMany: 4,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        debug_traceCall: 5,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        trace_filter: 6,
-      };
-
-      expect(result.providerRequestsCount).toStrictEqual(providerRequestsCount);
     });
 
     it('should throw error if the user has not enabled blockaid security check', async () => {
@@ -306,20 +222,23 @@ describe('PPOMController', () => {
 
     it(`should use old version info data that was fetched even if after CDN is updated,
         till next scheduled job to fetch data runs`, async () => {
-      const spyEmptyResponse = buildFetchSpy({
-        status: 200,
-        json: () => [],
-      });
+      const spyEmptyResponse = buildFetchSpy(
+        {
+          status: 200,
+          json: () => [],
+        },
+        undefined,
+        123,
+      );
       ppomController = buildPPOMController();
       jest.runAllTicks();
       await flushPromises();
       expect(spyEmptyResponse).toHaveBeenCalledTimes(2);
 
-      const spyWithResponse = buildFetchSpy();
-      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
-      jest.runOnlyPendingTimers();
-      expect(spyWithResponse).toHaveBeenCalledTimes(2);
+      buildFetchSpy();
 
+      // even though new version has files
+      // ppom continues to use old information till the new one is downloaded by scheduled job
       await expect(async () => {
         await ppomController.usePPOM(async () => {
           return Promise.resolve();
@@ -332,10 +251,11 @@ describe('PPOMController', () => {
     it('should throw error if file version info is not present for the network', async () => {
       buildFetchSpy({
         status: 200,
-        json: () => [],
+        json: () => undefined,
       });
       ppomController = buildPPOMController();
       jest.runOnlyPendingTimers();
+      await flushPromises();
       await expect(async () => {
         await ppomController.usePPOM(async () => {
           return Promise.resolve();
@@ -351,12 +271,13 @@ describe('PPOMController', () => {
       });
       ppomController = buildPPOMController();
       jest.runOnlyPendingTimers();
+      await flushPromises();
       await expect(async () => {
         await ppomController.usePPOM(async () => {
           return Promise.resolve();
         });
       }).rejects.toThrow(
-        'Failed to fetch file with url: https://ppom_cdn_base_url/blob',
+        'Aborting validation as not all files could not be downloaded for the network with chainId: 0x1',
       );
     });
 
@@ -376,11 +297,14 @@ describe('PPOMController', () => {
       });
       ppomController = buildPPOMController();
       jest.runOnlyPendingTimers();
+      await flushPromises();
       await expect(async () => {
         await ppomController.usePPOM(async () => {
           return Promise.resolve();
         });
-      }).rejects.toThrow('Invalid file path for data file: test~123$.2*()');
+      }).rejects.toThrow(
+        'Aborting validation as not all files could not be downloaded for the network with chainId: 0x1',
+      );
     });
 
     it('should not fail even if local storage files are corrupted', async () => {
@@ -393,6 +317,7 @@ describe('PPOMController', () => {
         }),
       });
       jest.runOnlyPendingTimers();
+      await flushPromises();
 
       await ppomController.usePPOM(async (ppom: any) => {
         expect(ppom).toBeDefined();
@@ -400,8 +325,8 @@ describe('PPOMController', () => {
       });
     });
 
-    it('should not fail even if local storage files are corrupted and CDN also not return file', async () => {
-      buildFetchSpy();
+    it('should fail if local storage files are corrupted and CDN also not return file', async () => {
+      buildFetchSpy(undefined, undefined, 123);
       let callBack: any;
       ppomController = buildPPOMController({
         storageBackend: buildStorageBackend({
@@ -412,28 +337,86 @@ describe('PPOMController', () => {
         onNetworkChange: (func: any) => {
           callBack = func;
         },
-        chainId: '0x2',
+        chainId: '0x1',
       });
-      callBack({ providerConfig: { chainId: '0x1' } });
       jest.runOnlyPendingTimers();
-
-      await ppomController.usePPOM(async (ppom: any) => {
-        expect(ppom).toBeDefined();
+      await flushPromises();
+      await ppomController.usePPOM(async () => {
         return Promise.resolve();
       });
       callBack({ providerConfig: { chainId: '0x2' } });
       callBack({ providerConfig: { chainId: '0x1' } });
-      jest.runOnlyPendingTimers();
-      buildFetchSpy(undefined, {
-        status: 500,
-      });
+      buildFetchSpy(
+        undefined,
+        {
+          status: 500,
+        },
+        456,
+      );
+      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL + 1);
+      jest.advanceTimersByTime(1);
+      await flushPromises();
+
       await expect(async () => {
         await ppomController.usePPOM(async () => {
           return Promise.resolve();
         });
       }).rejects.toThrow(
-        'Aborting validation as no files are found for the network with chainId: 0x1',
+        'Aborting validation as not all files could not be downloaded for the network with chainId: 0x1',
       );
+    });
+
+    it('should reset PPOM when network is switched', async () => {
+      buildFetchSpy();
+      let callBack: any;
+      const freeMock = jest.fn();
+      ppomController = buildPPOMController({
+        storageBackend: buildStorageBackend({
+          read: async (): Promise<any> => {
+            throw new Error('not found');
+          },
+        }),
+        onNetworkChange: (func: any) => {
+          callBack = func;
+        },
+        chainId: '0x2',
+        ppomProvider: {
+          ppomInit: () => undefined,
+          PPOM: new PPOMClass(undefined, freeMock),
+        },
+      });
+      callBack({ providerConfig: { chainId: '0x1' } });
+      await flushPromises();
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+      callBack({ providerConfig: { chainId: '0x2' } });
+      await flushPromises();
+      expect(freeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw error if PPOM init on network changs fails', async () => {
+      buildFetchSpy();
+      let callBack: any;
+      const newMock = jest.fn().mockImplementation(() => {
+        throw Error('test');
+      });
+      ppomController = buildPPOMController({
+        onNetworkChange: (func: any) => {
+          callBack = func;
+        },
+        chainId: '0x1',
+        ppomProvider: {
+          ppomInit: () => undefined,
+          PPOM: new PPOMClass(newMock),
+        },
+      });
+      callBack({ providerConfig: { chainId: '0x2' } });
+      await flushPromises();
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+      callBack({ providerConfig: { chainId: '0x1' } });
+      await flushPromises();
+      expect(newMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -445,6 +428,7 @@ describe('PPOMController', () => {
         await ppomController.updatePPOM();
       }).rejects.toThrow('User has securityAlertsEnabled set to false');
     });
+
     it('should throw error if fetch for version info return 500', async () => {
       buildFetchSpy({
         status: 500,
@@ -457,6 +441,7 @@ describe('PPOMController', () => {
         'Failed to fetch file with url: https://ppom_cdn_base_url/ppom_version.json',
       );
     });
+
     it('should not throw error if fetch for blob return 500', async () => {
       buildFetchSpy(undefined, {
         status: 500,
@@ -471,17 +456,25 @@ describe('PPOMController', () => {
       );
       await flushPromises();
     });
+
     it('should not fetch data for network if network data is already fetched', async () => {
       const spy = buildFetchSpy(undefined, undefined, 123);
       ppomController = buildPPOMController();
       jest.runOnlyPendingTimers();
+      await flushPromises();
+      expect(spy).toHaveBeenCalledTimes(3);
       await ppomController.updatePPOM();
       jest.runOnlyPendingTimers();
-      expect(spy).toHaveBeenCalledTimes(6);
+      await flushPromises();
+      // 4 calls to version info file and 2 data files
+      expect(spy).toHaveBeenCalledTimes(7);
       await ppomController.updatePPOM();
       jest.runOnlyPendingTimers();
-      expect(spy).toHaveBeenCalledTimes(8);
+      await flushPromises();
+      // 2 additional call this time is to version info HEAD
+      expect(spy).toHaveBeenCalledTimes(9);
     });
+
     it('should set dataFetched to true for supported chainIds in chainStatus', async () => {
       buildFetchSpy();
       let callBack: any;
@@ -500,6 +493,7 @@ describe('PPOMController', () => {
       expect(chainIdData1.dataFetched).toBe(true);
       expect(chainIdData2.dataFetched).toBe(false);
     });
+
     it('should get files for only supported chains in chainStatus', async () => {
       const spy = buildFetchSpy({
         status: 200,
@@ -529,8 +523,9 @@ describe('PPOMController', () => {
       await ppomController.updatePPOM();
       jest.runOnlyPendingTimers();
       await flushPromises();
-      expect(spy).toHaveBeenCalledTimes(10);
+      expect(spy).toHaveBeenCalledTimes(13);
     });
+
     it('should not re-throw error if file write fails', async () => {
       const spy = buildFetchSpy(undefined, undefined, 123);
       const storageBackend = buildStorageBackend({
@@ -544,8 +539,9 @@ describe('PPOMController', () => {
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(1);
       await ppomController.updatePPOM();
       jest.runOnlyPendingTimers();
-      expect(spy).toHaveBeenCalledTimes(6);
+      expect(spy).toHaveBeenCalledTimes(5);
     });
+
     it('should decrease scheduleInterval if its set very high', async () => {
       // here fileScheduleInterval is set very high but advance it by just REFRESH_TIME_INTERVAL
       // is helping fetch new files as value of fileScheduleInterval is adjusted to be able to fetch all data files
@@ -553,7 +549,7 @@ describe('PPOMController', () => {
       ppomController = buildPPOMController({
         fileFetchScheduleDuration: REFRESH_TIME_INTERVAL * 100,
       });
-      expect(spy).toHaveBeenCalledTimes(0);
+      expect(spy).toHaveBeenCalledTimes(1);
       jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
       await flushPromises();
       expect(spy).toHaveBeenCalledTimes(3);
@@ -561,6 +557,7 @@ describe('PPOMController', () => {
       await flushPromises();
       expect(spy).toHaveBeenCalledTimes(6);
     });
+
     it('should delete network more than a week old from chainStatus', async () => {
       buildFetchSpy();
       let callBack: any;
@@ -581,6 +578,7 @@ describe('PPOMController', () => {
       const chainIdData2 = ppomController.state.chainStatus['0x1'];
       expect(chainIdData2).toBeUndefined();
     });
+
     it('should not get files if ETag of version info file is not changed', async () => {
       const spy = buildFetchSpy(undefined, undefined, 1);
       ppomController = buildPPOMController();
@@ -596,6 +594,48 @@ describe('PPOMController', () => {
       jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
       await flushPromises();
       expect(spy).toHaveBeenCalledTimes(6);
+    });
+
+    it('should re-init ppom when new set of files are fetched', async () => {
+      buildFetchSpy();
+      const newMock = jest.fn();
+      ppomController = buildPPOMController({
+        ppomProvider: {
+          ppomInit: () => undefined,
+          PPOM: new PPOMClass(newMock),
+        },
+        fileFetchScheduleDuration: 0,
+      });
+      await flushPromises();
+      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
+      await flushPromises();
+      expect(newMock).toHaveBeenCalledTimes(1);
+
+      buildFetchSpy(
+        {
+          status: 200,
+          json: () => [
+            ...VERSION_INFO,
+            {
+              name: 'data2',
+              chainId: '0x1',
+              version: '1.0.3',
+              checksum:
+                '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49',
+              filePath: 'data2',
+            },
+          ],
+        },
+        undefined,
+        2,
+      );
+      await flushPromises();
+
+      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
+      await flushPromises();
+      jest.advanceTimersByTime(1);
+      await flushPromises();
+      expect(newMock).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -673,51 +713,27 @@ describe('PPOMController', () => {
 
     it('should reset PPOM when network is changed', async () => {
       buildFetchSpy();
-      const newMock = jest.fn().mockReturnValue('abc');
-      class PPOMClass {
-        #jsonRpcRequest: any;
-
-        constructor(newM: any) {
-          this.new = newM;
-        }
-
-        new = (jsonRpcRequest: any) => {
-          this.#jsonRpcRequest = jsonRpcRequest;
-          return this;
-        };
-
-        validateJsonRpc = async () => {
-          return Promise.resolve();
-        };
-
-        free = () => undefined;
-
-        testJsonRPCRequest = async (
-          method = 'eth_blockNumber',
-          args2: any = {},
-        ) => await this.#jsonRpcRequest(method, ...args2);
-      }
+      const freeMock = jest.fn().mockReturnValue('abc');
       let callBack: any;
       ppomController = buildPPOMController({
         onNetworkChange: (func: any) => {
           callBack = func;
         },
-        chainId: '0x2',
+        chainId: '0x1',
         ppomProvider: {
           ppomInit: () => undefined,
-          PPOM: new PPOMClass(newMock),
+          PPOM: new PPOMClass(undefined, freeMock),
         },
       });
 
+      await flushPromises();
+      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
+      await flushPromises();
+
+      expect(freeMock).toHaveBeenCalledTimes(0);
+      callBack({ providerConfig: { chainId: '0x2' } });
       callBack({ providerConfig: { chainId: '0x1' } });
-      jest.runOnlyPendingTimers();
-      expect(newMock).toHaveBeenCalledTimes(0);
-      await ppomController.usePPOM(async (ppom: any) => {
-        expect(ppom).toBeDefined();
-        expect(newMock).toHaveBeenCalledTimes(1);
-        return Promise.resolve();
-      });
-      jest.runOnlyPendingTimers();
+      expect(freeMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -769,7 +785,7 @@ describe('PPOMController', () => {
         },
       });
       jest.runOnlyPendingTimers();
-
+      await flushPromises();
       await ppomController.usePPOM(async (ppom: any) => {
         expect(ppom).toBeDefined();
         return Promise.resolve();
@@ -800,6 +816,104 @@ describe('PPOMController', () => {
       jest.runOnlyPendingTimers();
       await flushPromises();
       expect(spy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('jsonRPCRequest', () => {
+    it('should propogate to ppom in correct format if JSON RPC request on provider fails', async () => {
+      buildFetchSpy();
+      ppomController = buildPPOMController({
+        provider: {
+          sendAsync: (_arg1: any, arg2: any) => {
+            arg2('DUMMY_ERROR');
+          },
+        },
+      });
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+      const result = await ppomController.usePPOM(async (ppom: any) => {
+        return await ppom.testJsonRPCRequest();
+      });
+      expect(result.error).toBe('DUMMY_ERROR');
+    });
+
+    it('should not call provider if method call on provider is not allowed to PPOM', async () => {
+      buildFetchSpy();
+      const sendAsyncMock = jest.fn();
+      ppomController = buildPPOMController({
+        provider: {
+          sendAsync: sendAsyncMock,
+        },
+      });
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+      await ppomController.usePPOM(async (ppom: any) => {
+        await ppom.testJsonRPCRequest('DUMMY_METHOD');
+      });
+      expect(sendAsyncMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('should rate limit number of requests by PPOM on provider', async () => {
+      buildFetchSpy();
+      ppomController = buildPPOMController({
+        provider: {
+          sendAsync: (_arg1: any, arg2: any) => {
+            arg2(undefined, 'DUMMY_VALUE');
+          },
+        },
+        providerRequestLimit: 5,
+      });
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+
+      await ppomController.usePPOM(async (ppom: any) => {
+        await ppom.testJsonRPCRequest();
+        await ppom.testJsonRPCRequest();
+        await ppom.testJsonRPCRequest();
+        await ppom.testJsonRPCRequest();
+        await ppom.testJsonRPCRequest();
+        await ppom.testJsonRPCRequest();
+        const result = await ppom.testJsonRPCRequest();
+        expect(result.error.code).toBe(
+          Utils.PROVIDER_ERRORS.limitExceeded().error.code,
+        );
+      });
+    });
+
+    it('should record number of times each RPC method is called and return it in response', async () => {
+      buildFetchSpy();
+      ppomController = buildPPOMController({
+        provider: {
+          sendAsync: (_arg1: any, arg2: any) => {
+            arg2(undefined, 'DUMMY_VALUE');
+          },
+        },
+        providerRequestLimit: 25,
+      });
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+
+      const result = await ppomController.usePPOM(async (ppom: any) => {
+        await ppom.testCallRpcRequests();
+        return Promise.resolve(buildDummyResponse());
+      });
+
+      const providerRequestsCount = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        eth_getBalance: 1,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        eth_getTransactionCount: 2,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        trace_call: 3,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        trace_callMany: 4,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        debug_traceCall: 5,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        trace_filter: 6,
+      };
+
+      expect(result.providerRequestsCount).toStrictEqual(providerRequestsCount);
     });
   });
 });

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -419,6 +419,8 @@ export class PPOMController extends BaseControllerV2<
   #clearDataFetchIntervals() {
     clearInterval(this.#refreshDataInterval);
     clearInterval(this.#fileScheduleInterval);
+    this.#refreshDataInterval = undefined;
+    this.#fileScheduleInterval = undefined;
   }
 
   /*
@@ -1035,7 +1037,7 @@ export class PPOMController extends BaseControllerV2<
     });
   }
 
-  /**
+  /*
    * The function invokes the task to fetch files of all the chains and then
    * starts the scheduled periodic task to fetch files for all the chains.
    */

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -974,6 +974,9 @@ export class PPOMController extends BaseControllerV2<
    * It will load the data files from storage and pass data files and wasm file to ppom.
    */
   async #getPPOM(): Promise<any> {
+    // For some reason ppom initialisation in contrructor fails for react native
+    // thus it is added here to prevent validation from failing.
+    this.#initialisePPOM();
     this.#ppomInitError = undefined;
     const { chainStatus } = this.state;
     const chainInfo = chainStatus[this.#chainId];

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,11 +1,6 @@
 import fs from 'fs';
 
-import {
-  addHexPrefix,
-  constructURLHref,
-  isDeepEqual,
-  validateSignature,
-} from './util';
+import { addHexPrefix, constructURLHref, validateSignature } from './util';
 
 const TEST_PUBLIC_KEY =
   '821e94d60bf030d7f5c399f751324093363a229acc1aa77cfbd795a0e62ff947';
@@ -67,17 +62,6 @@ describe('Util', () => {
       expect(addHexPrefix('123')).toBe('0x123');
       expect(addHexPrefix('0X123')).toBe('0x123');
       expect(addHexPrefix('0x123')).toBe('0x123');
-    });
-  });
-  describe('isDeepEqual', () => {
-    it('should check equality correctly', () => {
-      const obj = { a: 'a' };
-      expect(isDeepEqual(obj, obj)).toBe(true);
-      expect(isDeepEqual(null, obj)).toBe(false);
-      expect(isDeepEqual(obj, null)).toBe(false);
-      expect(isDeepEqual(obj, { b: 'b' })).toBe(false);
-      expect(isDeepEqual({ b: 'b' }, { b: 'b' })).toBe(true);
-      expect(isDeepEqual({ b: 'b' }, { b: 'bc' })).toBe(false);
     });
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -68,35 +68,3 @@ export const addHexPrefix = (str: string) => {
 
   return `0x${str}`;
 };
-
-/*
- * Simplified implementation of deep equality check of objects in Javascript.
- */
-export const isDeepEqual = (a: any, b: any) => {
-  if (a === b) {
-    return true;
-  }
-
-  if (typeof a !== 'object' || typeof b !== 'object' || !a || !b) {
-    return false;
-  }
-
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-
-  if (keysA.length !== keysB.length) {
-    return false;
-  }
-
-  for (const key of keysA) {
-    if (!keysB.includes(key)) {
-      return false;
-    }
-
-    if (a[key].toString() !== b[key].toString()) {
-      return false;
-    }
-  }
-
-  return true;
-};

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -108,8 +108,17 @@ export const buildFetchSpy = (
     });
 };
 
-class PPOMClass {
+export class PPOMClass {
   #jsonRpcRequest: any;
+
+  constructor(newMock?: any, freeMock?: any) {
+    if (newMock) {
+      this.new = newMock;
+    }
+    if (freeMock) {
+      this.free = freeMock;
+    }
+  }
 
   new = (jsonRpcRequest: any) => {
     this.#jsonRpcRequest = jsonRpcRequest;
@@ -122,8 +131,8 @@ class PPOMClass {
 
   free = () => undefined;
 
-  testJsonRPCRequest = async (method: string, args2: any) =>
-    await this.#jsonRpcRequest(method ?? 'eth_blockNumber', args2);
+  testJsonRPCRequest = async (method: string) =>
+    await this.#jsonRpcRequest(method ?? 'eth_blockNumber');
 
   testCallRpcRequests = async () => {
     const methods = [


### PR DESCRIPTION
Fixes: MetaMask/MetaMask-planning#1555

The PR makes invoking `PPOM.new` async, thus it is done as soon ad all files of current network are downloaded, it is not deferred to the time when transaction is received.

The PR also has some code cleanup and adding comments,