### PR TITLE
Support optional `networkClientId` in `usePPOM()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0]
+### Changed
+- Fix PPOM initialisation in mobile ([#83](https://github.com/MetaMask/ppom-validator/pull/83))
+- Instantiate PPOM per request ([#81](https://github.com/MetaMask/ppom-validator/pull/81))
+
 ## [0.9.0]
 ### Changed
 - Performance Improvement: async instantation of PPOM instance by passing data files ([#77](https://github.com/MetaMask/ppom-validator/pull/77))
@@ -70,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restrict provider access to PPOM ([#7](https://github.com/MetaMask/ppom-validator/pull/7))
 - Integrate with ppom npm module ([#8](https://github.com/MetaMask/ppom-validator/pull/8))
 
-[Unreleased]: https://github.com/MetaMask/ppom-validator/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/MetaMask/ppom-validator/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/MetaMask/ppom-validator/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/MetaMask/ppom-validator/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/MetaMask/ppom-validator/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/MetaMask/ppom-validator/compare/v0.6.0...v0.7.0

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.0.0",
-    "@metamask/controller-utils": "^4.0.0",
+    "@metamask/base-controller": "^3.2.1",
+    "@metamask/controller-utils": "^5.0.0",
+    "@metamask/network-controller": "^15.2.0",
     "await-semaphore": "^0.1.3",
     "elliptic": "^6.5.4",
     "json-rpc-random-id": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ppom-validator",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "This module has code to integrate Blockaid PPOM with MetaMask",
   "homepage": "https://github.com/MetaMask/ppom-validator#readme",
   "bugs": {

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -637,30 +637,6 @@ describe('PPOMController', () => {
       expect(chainIdData2).toBeDefined();
     });
 
-    it('should add new network from configs to chainStatus if not already added', () => {
-      buildFetchSpy();
-      let callBack: any;
-      ppomController = buildPPOMController({
-        onNetworkChange: (func: any) => {
-          callBack = func;
-        },
-      });
-
-      const chainIdData1 = ppomController.state.chainStatus['0x1'];
-      expect(chainIdData1).toBeDefined();
-      callBack({
-        providerConfig: { chainId: '0x1' },
-        networkConfigurations: {
-          id1: { chainId: '0x3' },
-          id2: { chainId: '0x4' },
-        },
-      });
-      const chainIdData3 = ppomController.state.chainStatus['0x3'];
-      expect(chainIdData3).toBeDefined();
-      const chainIdData4 = ppomController.state.chainStatus['0x4'];
-      expect(chainIdData4).toBeDefined();
-    });
-
     it('should update lastVisited time in chainStatus if network is already added', async () => {
       buildFetchSpy();
       let callBack: any;

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -1,5 +1,4 @@
 import {
-  PPOMClass,
   VERSION_INFO,
   buildDummyResponse,
   buildFetchSpy,
@@ -365,59 +364,6 @@ describe('PPOMController', () => {
         'Aborting validation as not all files could not be downloaded for the network with chainId: 0x1',
       );
     });
-
-    it('should reset PPOM when network is switched', async () => {
-      buildFetchSpy();
-      let callBack: any;
-      const freeMock = jest.fn();
-      ppomController = buildPPOMController({
-        storageBackend: buildStorageBackend({
-          read: async (): Promise<any> => {
-            throw new Error('not found');
-          },
-        }),
-        onNetworkChange: (func: any) => {
-          callBack = func;
-        },
-        chainId: '0x2',
-        ppomProvider: {
-          ppomInit: () => undefined,
-          PPOM: new PPOMClass(undefined, freeMock),
-        },
-      });
-      callBack({ providerConfig: { chainId: '0x1' } });
-      await flushPromises();
-      jest.runOnlyPendingTimers();
-      await flushPromises();
-      callBack({ providerConfig: { chainId: '0x2' } });
-      await flushPromises();
-      expect(freeMock).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not throw error if PPOM init on network changs fails', async () => {
-      buildFetchSpy();
-      let callBack: any;
-      const newMock = jest.fn().mockImplementation(() => {
-        throw Error('test');
-      });
-      ppomController = buildPPOMController({
-        onNetworkChange: (func: any) => {
-          callBack = func;
-        },
-        chainId: '0x1',
-        ppomProvider: {
-          ppomInit: () => undefined,
-          PPOM: new PPOMClass(newMock),
-        },
-      });
-      callBack({ providerConfig: { chainId: '0x2' } });
-      await flushPromises();
-      jest.runOnlyPendingTimers();
-      await flushPromises();
-      callBack({ providerConfig: { chainId: '0x1' } });
-      await flushPromises();
-      expect(newMock).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('updatePPOM', () => {
@@ -595,48 +541,6 @@ describe('PPOMController', () => {
       await flushPromises();
       expect(spy).toHaveBeenCalledTimes(6);
     });
-
-    it('should re-init ppom when new set of files are fetched', async () => {
-      buildFetchSpy();
-      const newMock = jest.fn();
-      ppomController = buildPPOMController({
-        ppomProvider: {
-          ppomInit: () => undefined,
-          PPOM: new PPOMClass(newMock),
-        },
-        fileFetchScheduleDuration: 0,
-      });
-      await flushPromises();
-      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
-      await flushPromises();
-      expect(newMock).toHaveBeenCalledTimes(1);
-
-      buildFetchSpy(
-        {
-          status: 200,
-          json: () => [
-            ...VERSION_INFO,
-            {
-              name: 'data2',
-              chainId: '0x1',
-              version: '1.0.3',
-              checksum:
-                '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49',
-              filePath: 'data2',
-            },
-          ],
-        },
-        undefined,
-        2,
-      );
-      await flushPromises();
-
-      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
-      await flushPromises();
-      jest.advanceTimersByTime(1);
-      await flushPromises();
-      expect(newMock).toHaveBeenCalledTimes(3);
-    });
   });
 
   describe('onNetworkChange', () => {
@@ -709,31 +613,6 @@ describe('PPOMController', () => {
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(5);
 
       expect(ppomController.state.chainStatus['0x1']).toBeUndefined();
-    });
-
-    it('should reset PPOM when network is changed', async () => {
-      buildFetchSpy();
-      const freeMock = jest.fn().mockReturnValue('abc');
-      let callBack: any;
-      ppomController = buildPPOMController({
-        onNetworkChange: (func: any) => {
-          callBack = func;
-        },
-        chainId: '0x1',
-        ppomProvider: {
-          ppomInit: () => undefined,
-          PPOM: new PPOMClass(undefined, freeMock),
-        },
-      });
-
-      await flushPromises();
-      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
-      await flushPromises();
-
-      expect(freeMock).toHaveBeenCalledTimes(0);
-      callBack({ providerConfig: { chainId: '0x2' } });
-      callBack({ providerConfig: { chainId: '0x1' } });
-      expect(freeMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -391,6 +391,7 @@ describe('PPOMController', () => {
         },
       });
       jest.runOnlyPendingTimers();
+      await flushPromises();
 
       await ppomController.usePPOM(async (ppom: any) => {
         const result = await ppom.testJsonRPCRequest();
@@ -411,6 +412,7 @@ describe('PPOMController', () => {
         },
       });
       jest.runOnlyPendingTimers();
+      await flushPromises();
 
       await expect(async () => {
         await ppomController.usePPOM(async () => {

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -343,8 +343,14 @@ describe('PPOMController', () => {
       await ppomController.usePPOM(async () => {
         return Promise.resolve();
       });
-      callBack({ providerConfig: { chainId: '0x2' } });
-      callBack({ providerConfig: { chainId: '0x1' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x2' },
+      });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x1' },
+      });
       buildFetchSpy(
         undefined,
         {
@@ -484,7 +490,10 @@ describe('PPOMController', () => {
         },
       });
       jest.runOnlyPendingTimers();
-      callBack({ providerConfig: { chainId: '0x2' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x2' },
+      });
       await ppomController.updatePPOM();
       jest.runOnlyPendingTimers();
       await flushPromises();
@@ -518,7 +527,10 @@ describe('PPOMController', () => {
         },
       });
       jest.runOnlyPendingTimers();
-      callBack({ providerConfig: { chainId: '0x2' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x2' },
+      });
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(2);
       await ppomController.updatePPOM();
       jest.runOnlyPendingTimers();
@@ -570,8 +582,14 @@ describe('PPOMController', () => {
       await flushPromises();
       const chainIdData1 = ppomController.state.chainStatus['0x1'];
       expect(chainIdData1).toBeDefined();
-      callBack({ providerConfig: { chainId: '0x2' } });
-      callBack({ providerConfig: { chainId: '0x3' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x2' },
+      });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x3' },
+      });
       jest.advanceTimersByTime(NETWORK_CACHE_DURATION);
       jest.runOnlyPendingTimers();
       await flushPromises();
@@ -598,7 +616,7 @@ describe('PPOMController', () => {
   });
 
   describe('onNetworkChange', () => {
-    it('should add network to chainStatus if not already added', () => {
+    it('should add current network to chainStatus if not already added', () => {
       buildFetchSpy();
       let callBack: any;
       ppomController = buildPPOMController({
@@ -609,9 +627,36 @@ describe('PPOMController', () => {
 
       const chainIdData1 = ppomController.state.chainStatus['0x1'];
       expect(chainIdData1).toBeDefined();
-      callBack({ providerConfig: { chainId: '0x2' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x2' },
+      });
       const chainIdData2 = ppomController.state.chainStatus['0x2'];
       expect(chainIdData2).toBeDefined();
+    });
+
+    it('should add new network from configs to chainStatus if not already added', () => {
+      buildFetchSpy();
+      let callBack: any;
+      ppomController = buildPPOMController({
+        onNetworkChange: (func: any) => {
+          callBack = func;
+        },
+      });
+
+      const chainIdData1 = ppomController.state.chainStatus['0x1'];
+      expect(chainIdData1).toBeDefined();
+      callBack({
+        providerConfig: { chainId: '0x1' },
+        networkConfigurations: {
+          id1: { chainId: '0x3' },
+          id2: { chainId: '0x4' },
+        },
+      });
+      const chainIdData3 = ppomController.state.chainStatus['0x3'];
+      expect(chainIdData3).toBeDefined();
+      const chainIdData4 = ppomController.state.chainStatus['0x4'];
+      expect(chainIdData4).toBeDefined();
     });
 
     it('should update lastVisited time in chainStatus if network is already added', async () => {
@@ -629,8 +674,14 @@ describe('PPOMController', () => {
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-02'));
 
-      callBack({ providerConfig: { chainId: '0x2' } });
-      callBack({ providerConfig: { chainId: '0x1' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x2' },
+      });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x1' },
+      });
       const lastVisitedAfter =
         ppomController.state.chainStatus['0x1'].lastVisited;
       expect(lastVisitedBefore !== lastVisitedAfter).toBe(true);
@@ -649,21 +700,36 @@ describe('PPOMController', () => {
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(1);
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-02'));
-      callBack({ providerConfig: { chainId: '0x2' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x2' },
+      });
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-05'));
-      callBack({ providerConfig: { chainId: '0x5' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x5' },
+      });
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-03'));
-      callBack({ providerConfig: { chainId: '0x3' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x3' },
+      });
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-04'));
-      callBack({ providerConfig: { chainId: '0x4' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x4' },
+      });
 
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(5);
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-06'));
-      callBack({ providerConfig: { chainId: '0x6' } });
+      callBack({
+        networkConfigurations: {},
+        providerConfig: { chainId: '0x6' },
+      });
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(5);
 
       expect(ppomController.state.chainStatus['0x1']).toBeUndefined();

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -546,9 +546,9 @@ export class PPOMController extends BaseControllerV2<
   }
 
   /*
-   * The function will return true if data is not already fetched for all chains.
+   * The function will return true if data is not already fetched for any chain.
    */
-  #isDataRequiredForAllChains(): boolean {
+  #isDataRequiredForAnyChain(): boolean {
     const isDataRequiredForChain = this.#isDataRequiredForChain.bind(this);
     return Object.keys(this.state.chainStatus).some(isDataRequiredForChain);
   }
@@ -559,7 +559,7 @@ export class PPOMController extends BaseControllerV2<
    */
   async #updatePPOM(): Promise<void> {
     const versionInfoUpdated = await this.#updateVersionInfo();
-    if (versionInfoUpdated || this.#isDataRequiredForAllChains()) {
+    if (versionInfoUpdated || this.#isDataRequiredForAnyChain()) {
       await this.#getNewFilesForAllChains();
     }
   }

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -503,12 +503,6 @@ export class PPOMController extends BaseControllerV2<
   #onNetworkChange(networkControllerState: NetworkState): void {
     this.#chainId = addHexPrefix(networkControllerState.providerConfig.chainId);
     this.#updateChainStatus(this.#chainId);
-    Object.values(networkControllerState.networkConfigurations).forEach(
-      (networkConfig) => {
-        const chainId = addHexPrefix(networkConfig.chainId);
-        this.#updateChainStatus(chainId);
-      },
-    );
     this.#deleteOldChainIds();
     this.#checkScheduleFileDownloadForAllChains();
   }

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -550,12 +550,20 @@ export class PPOMController extends BaseControllerV2<
   }
 
   /*
+   * The function will return true if data is not already fetched for all chains.
+   */
+  #isDataRequiredForAllChains(): boolean {
+    const isDataRequiredForChain = this.#isDataRequiredForChain.bind(this);
+    return Object.keys(this.state.chainStatus).some(isDataRequiredForChain);
+  }
+
+  /*
    * Update the PPOM configuration for all chainId.
    * If new version info file is available the function will update data files for all chains.
    */
   async #updatePPOM(): Promise<void> {
     const versionInfoUpdated = await this.#updateVersionInfo();
-    if (versionInfoUpdated) {
+    if (versionInfoUpdated || this.#isDataRequiredForAllChains()) {
       await this.#getNewFilesForAllChains();
     }
   }

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -155,10 +155,6 @@ export class PPOMController extends BaseControllerV2<
   PPOMState,
   PPOMControllerMessenger
 > {
-  #ppom: any;
-
-  #ppomInitError: any;
-
   #provider: any;
 
   #storage: PPOMStorage;
@@ -351,15 +347,16 @@ export class PPOMController extends BaseControllerV2<
       throw Error('Blockaid validation is available only on ethereum mainnet');
     }
 
-    await this.#reinitPPOMForNetworkIfRequired();
-    if (this.#ppomInitError) {
-      throw new Error(this.#ppomInitError);
-    }
+    await this.#getNewFilesForCurrentChainIfNeeded();
 
     this.#providerRequests = 0;
     this.#providerRequestsCount = {};
+
     return await this.#ppomMutex.use(async () => {
-      const result = await callback(this.#ppom);
+      const ppom = await this.#getPPOM();
+      const result = await callback(ppom);
+
+      ppom.free();
 
       return {
         ...result,
@@ -430,7 +427,6 @@ export class PPOMController extends BaseControllerV2<
    * 3. clears version information of data files
    */
   #resetToInactiveState() {
-    this.#resetPPOM();
     this.#clearDataFetchIntervals();
     this.update((draftState) => {
       draftState.versionInfo = [];
@@ -459,7 +455,6 @@ export class PPOMController extends BaseControllerV2<
     const id = addHexPrefix(networkControllerState.providerConfig.chainId);
     let chainStatus = { ...this.state.chainStatus };
     const existingNetworkObject = chainStatus[id];
-    const oldChainId = this.#chainId;
     this.#chainId = id;
     chainStatus = {
       ...chainStatus,
@@ -475,15 +470,6 @@ export class PPOMController extends BaseControllerV2<
     });
     this.#deleteOldChainIds();
     this.#checkScheduleFileDownloadForAllChains();
-    if (oldChainId !== id) {
-      if (chainStatus[id]?.dataFetched) {
-        this.#reinitPPOM().catch(() => {
-          console.error('Error in re-init of PPOM');
-        });
-      } else {
-        this.#resetPPOM();
-      }
-    }
   }
 
   /*
@@ -517,36 +503,6 @@ export class PPOMController extends BaseControllerV2<
       `${controllerName}:updatePPOM` as const,
       this.updatePPOM.bind(this),
     );
-  }
-
-  /*
-   * The function resets PPOM.
-   */
-  #resetPPOM(): void {
-    if (this.#ppom) {
-      this.#ppom.free();
-      this.#ppom = undefined;
-    }
-  }
-
-  /*
-   * The function initialises PPOM.
-   */
-  async #reinitPPOM(): Promise<void> {
-    this.#resetPPOM();
-    this.#ppom = await this.#getPPOM();
-  }
-
-  /**
-   * Conditionally update the ppom configuration.
-   *
-   * The function will check if files are required to be downloaded and
-   * if needed will re-initialise PPOM passing new network files to it.
-   */
-  async #reinitPPOMForNetworkIfRequired(): Promise<void> {
-    if (this.#isDataRequiredForCurrentChain()) {
-      await this.#getNewFilesForCurrentChain();
-    }
   }
 
   /*
@@ -680,20 +636,23 @@ export class PPOMController extends BaseControllerV2<
    * The function is invoked if user if attempting transaction for current network,
    * for which data is not previously fetched.
    */
-  async #getNewFilesForCurrentChain(): Promise<void> {
-    for (const fileVersionInfo of this.state.versionInfo) {
-      if (fileVersionInfo.chainId !== this.#chainId) {
-        continue;
-      }
-
-      await this.#getFile(fileVersionInfo).catch((exp: Error) => {
-        console.error(
-          `Error in getting file ${fileVersionInfo.filePath}: ${exp.message}`,
-        );
-      });
+  async #getNewFilesForCurrentChainIfNeeded(): Promise<void> {
+    if (!this.#isDataRequiredForCurrentChain()) {
+      return;
     }
+    const versionInfoForCurrentChain = this.state.versionInfo.filter(
+      ({ chainId }) => chainId === this.#chainId,
+    );
+    await Promise.all(
+      versionInfoForCurrentChain.map(async (fileVersionInfo) => {
+        await this.#getFile(fileVersionInfo).catch((exp: Error) => {
+          console.error(
+            `Error in getting file ${fileVersionInfo.filePath}: ${exp.message}`,
+          );
+        });
+      }),
+    );
     await this.#setChainIdDataFetched(this.#chainId);
-    await this.#reinitPPOM();
   }
 
   /*
@@ -824,9 +783,6 @@ export class PPOMController extends BaseControllerV2<
               if (isLastFileOfNetwork) {
                 // if this was last file for the chainId set dataFetched for chainId to true
                 await this.#setChainIdDataFetched(fileVersionInfo.chainId);
-                if (fileVersionInfo.chainId === this.#chainId) {
-                  await this.#reinitPPOM();
-                }
               }
             })
             .catch((exp: Error) =>
@@ -977,14 +933,14 @@ export class PPOMController extends BaseControllerV2<
     // For some reason ppom initialisation in contrructor fails for react native
     // thus it is added here to prevent validation from failing.
     this.#initialisePPOM();
-    this.#ppomInitError = undefined;
     const { chainStatus } = this.state;
     const chainInfo = chainStatus[this.#chainId];
     if (!chainInfo?.versionInfo?.length) {
-      this.#ppomInitError = `Aborting validation as no files are found for the network with chainId: ${
-        this.#chainId
-      }`;
-      return undefined;
+      throw new Error(
+        `Aborting validation as no files are found for the network with chainId: ${
+          this.#chainId
+        }`,
+      );
     }
     // Get all the files for  the chainId
     let files = await Promise.all(
@@ -1019,16 +975,15 @@ export class PPOMController extends BaseControllerV2<
     // If we want to disable ppom validation on all instances of Metamask,
     // this can be achieved by returning empty data from version file.
     if (files.length !== chainInfo?.versionInfo?.length) {
-      this.#ppomInitError = `Aborting validation as not all files could not be downloaded for the network with chainId: ${
-        this.#chainId
-      }`;
-      return undefined;
+      throw new Error(
+        `Aborting validation as not all files could not be downloaded for the network with chainId: ${
+          this.#chainId
+        }`,
+      );
     }
 
-    return await this.#ppomMutex.use(async () => {
-      const { PPOM } = this.#ppomProvider;
-      return PPOM.new(this.#jsonRpcRequest.bind(this), files);
-    });
+    const { PPOM } = this.#ppomProvider;
+    return PPOM.new(this.#jsonRpcRequest.bind(this), files);
   }
 
   /**

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -375,7 +375,7 @@ export class PPOMController extends BaseControllerV2<
     await Promise.all([
       this.#getNewFilesForChainIfNeeded(chainId),
       this.#initialisePPOM(),
-    ])
+    ]);
 
     return await this.#ppomMutex.use(async () => {
       const ppom = await this.#getPPOM(chainId, provider);
@@ -501,10 +501,13 @@ export class PPOMController extends BaseControllerV2<
    */
   #onNetworkChange(networkControllerState: NetworkState): void {
     this.#chainId = addHexPrefix(networkControllerState.providerConfig.chainId);
-    Object.values(networkControllerState.networkConfigurations).forEach(networkConfig => {
-      const chainId = addHexPrefix(networkConfig.chainId)
-      this.#updateChainStatus(chainId);
-    });
+    this.#updateChainStatus(this.#chainId);
+    Object.values(networkControllerState.networkConfigurations).forEach(
+      (networkConfig) => {
+        const chainId = addHexPrefix(networkConfig.chainId);
+        this.#updateChainStatus(chainId);
+      },
+    );
     this.#deleteOldChainIds();
     this.#checkScheduleFileDownloadForAllChains();
   }

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -362,11 +362,12 @@ export class PPOMController extends BaseControllerV2<
       chainId = networkClient.configuration.chainId;
       provider = networkClient.provider;
     }
-    this.#updateChainStatus(chainId);
 
     if (!this.#networkIsSupported(chainId)) {
       throw Error('Blockaid validation is available only on ethereum mainnet');
     }
+
+    this.#updateChainStatus(chainId);
 
     await Promise.all([
       this.#getNewFilesForChainIfNeeded(chainId),

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -367,6 +367,7 @@ export class PPOMController extends BaseControllerV2<
       chainId = networkClient.configuration.chainId;
       provider = networkClient.provider;
     }
+    this.#updateChainStatus(chainId);
 
     if (!this.#networkIsSupported(chainId)) {
       throw Error('Blockaid validation is available only on ethereum mainnet');

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -498,7 +498,7 @@ export class PPOMController extends BaseControllerV2<
   }
 
   /*
-   * The function adds new network to chainStatus list.
+   * Update chainStatus list and perform scheduled checks on network state changes
    */
   #onNetworkChange(networkControllerState: NetworkState): void {
     this.#chainId = addHexPrefix(networkControllerState.providerConfig.chainId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,33 +405,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainsafe/as-sha256@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@chainsafe/as-sha256@npm:0.4.1"
-  checksum: 6d86975e648ecdafd366802278ac15b392b252e967f3681412ec48b5a3518b936cc5e977517499882b084991446d25787d98f8f585891943688cc81549a44e9a
-  languageName: node
-  linkType: hard
-
-"@chainsafe/persistent-merkle-tree@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "@chainsafe/persistent-merkle-tree@npm:0.6.1"
-  dependencies:
-    "@chainsafe/as-sha256": ^0.4.1
-    "@noble/hashes": ^1.3.0
-  checksum: 74614b8d40970dc930d5bf741619498b0bbbde5ff24ce45fce6ad122143aa77bf57249a28175b1b972cf56bff57d529a4258b7222ab4e60c1261119b5986c51b
-  languageName: node
-  linkType: hard
-
-"@chainsafe/ssz@npm:^0.11.1":
-  version: 0.11.1
-  resolution: "@chainsafe/ssz@npm:0.11.1"
-  dependencies:
-    "@chainsafe/as-sha256": ^0.4.1
-    "@chainsafe/persistent-merkle-tree": ^0.6.1
-  checksum: e3c2928f9ab4a0544e645f0302b9535046d1e6e1d4b3bd1c3dd6bc8e6302fddad6036d65e7900d1446f285f496051da05fa14c1bde590b511d03033907175c8f
-  languageName: node
-  linkType: hard
-
 "@cspotcode/source-map-consumer@npm:0.8.0":
   version: 0.8.0
   resolution: "@cspotcode/source-map-consumer@npm:0.8.0"
@@ -476,13 +449,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/common@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "@ethereumjs/common@npm:3.1.2"
+"@ethereumjs/common@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@ethereumjs/common@npm:3.2.0"
   dependencies:
-    "@ethereumjs/util": ^8.0.6
+    "@ethereumjs/util": ^8.1.0
     crc-32: ^1.2.0
-  checksum: e80a8bc86476f1ce878bacb1915d91681671bb5303291cdcece26e456ac13a6158f0f59625cb02a1cfbdd7c9a7dc8b175f8d8f0fee596b3eb9dfb965465ad43d
+  checksum: cb9cc11f5c868cb577ba611cebf55046e509218bbb89b47ccce010776dafe8256d70f8f43fab238aec74cf71f62601cd5842bc03a83261200802de365732a14b
   languageName: node
   linkType: hard
 
@@ -495,33 +468,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethereumjs/tx@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "@ethereumjs/tx@npm:4.1.2"
+"@ethereumjs/tx@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@ethereumjs/tx@npm:4.2.0"
   dependencies:
-    "@chainsafe/ssz": ^0.11.1
-    "@ethereumjs/common": ^3.1.2
+    "@ethereumjs/common": ^3.2.0
     "@ethereumjs/rlp": ^4.0.1
-    "@ethereumjs/util": ^8.0.6
+    "@ethereumjs/util": ^8.1.0
     ethereum-cryptography: ^2.0.0
-  peerDependencies:
-    c-kzg: ^1.0.8
-  peerDependenciesMeta:
-    c-kzg:
-      optional: true
-  checksum: ad2fb692c3746cd5935b01c98b6b54046ae2a1fccff57ad2209e10446f3b279a204d7477accf05b27078445b14379314077769662142ac07117c45a5a1ea427f
+  checksum: 87a3f5f2452cfbf6712f8847525a80c213210ed453c211c793c5df801fe35ecef28bae17fadd222fcbdd94277478a47e52d2b916a90a6b30cda21f1e0cdaee42
   languageName: node
   linkType: hard
 
-"@ethereumjs/util@npm:^8.0.6":
-  version: 8.0.6
-  resolution: "@ethereumjs/util@npm:8.0.6"
+"@ethereumjs/util@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@ethereumjs/util@npm:8.1.0"
   dependencies:
-    "@chainsafe/ssz": ^0.11.1
     "@ethereumjs/rlp": ^4.0.1
     ethereum-cryptography: ^2.0.0
     micro-ftch: ^0.3.1
-  checksum: 034e06cddec27417318434a1a7cd7a9dc0f0b447c1f54423c515d8809c9697386eee6429d0a1c13517a85c696e6fdba570b243d882e65764c274859606027015
+  checksum: 9ae5dee8f12b0faf81cd83f06a41560e79b0ba96a48262771d897a510ecae605eb6d84f687da001ab8ccffd50f612ae50f988ef76e6312c752897f462f3ac08d
   languageName: node
   linkType: hard
 
@@ -921,6 +887,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/abi-utils@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@metamask/abi-utils@npm:2.0.2"
+  dependencies:
+    "@metamask/utils": ^8.0.0
+    superstruct: ^1.0.3
+  checksum: 5ec153e7691a4e1dc8738a0ba1a99a354ddb13851fa88a40a19f002f6308310e71c2cee28c3a25d9f7f67e839c7dffe4760e93e308dd17fa725b08d0dc73a3d4
+  languageName: node
+  linkType: hard
+
 "@metamask/auto-changelog@npm:^3.1.0":
   version: 3.2.0
   resolution: "@metamask/auto-changelog@npm:3.2.0"
@@ -935,29 +911,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^3.0.0":
-  version: 3.2.1
-  resolution: "@metamask/base-controller@npm:3.2.1"
+"@metamask/base-controller@npm:^3.2.1, @metamask/base-controller@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "@metamask/base-controller@npm:3.2.3"
   dependencies:
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     immer: ^9.0.6
-  checksum: 73723a275ad2c8c6f9fcfcd69fd8b469bf8f4455fc572fc19ac9a8d76e5b65152cb111d95bfb9a4b9443298147e03a5f9778747dec2ca2203495ace54c97688c
+  checksum: f49fcf2bf892ec25657c2d72a50b3c4f3cad59acb1b74d9fdcdf564107b8f38f73647c696aaa9699d94828b5797d8f1479dab44a2dbcda987c268b0088bb3b76
   languageName: node
   linkType: hard
 
-"@metamask/controller-utils@npm:^4.0.0":
-  version: 4.3.2
-  resolution: "@metamask/controller-utils@npm:4.3.2"
+"@metamask/controller-utils@npm:^5.0.0, @metamask/controller-utils@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@metamask/controller-utils@npm:5.0.2"
   dependencies:
     "@metamask/eth-query": ^3.0.1
-    "@metamask/utils": ^6.2.0
+    "@metamask/utils": ^8.1.0
     "@spruceid/siwe-parser": 1.1.3
     eth-ens-namehash: ^2.0.8
-    eth-rpc-errors: ^4.0.2
     ethereumjs-util: ^7.0.10
     ethjs-unit: ^0.1.6
     fast-deep-equal: ^3.1.3
-  checksum: 0af7de11bee8cea81946c424d51e2f0a27f3deeebb491aed00262b2f76b4b1e16ff8fa129309944b3e16a6531b0d153dde6794011bf355234fdebb965261372e
+  checksum: 2345ab9ee0ba900fe2249d80009acfcf458bc60b30418234d00f5f04247b1182a585050572237f8ab09aa23032a24b99ad96399fc0798a0e9a114a29c3bf90d6
   languageName: node
   linkType: hard
 
@@ -1010,6 +985,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-json-rpc-infura@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/eth-json-rpc-infura@npm:9.0.0"
+  dependencies:
+    "@metamask/eth-json-rpc-provider": ^2.1.0
+    "@metamask/json-rpc-engine": ^7.1.1
+    "@metamask/rpc-errors": ^6.0.0
+    "@metamask/utils": ^8.1.0
+    node-fetch: ^2.6.7
+  checksum: 3dd6783dd54a72fc479496212524150e3e3f6869a135a02709d3ef9c2d7a2e2b99690eef91776c269da3c0d79709daed0c8693549cb8dd999e5b3d96e0b106c0
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-middleware@npm:^12.0.1":
+  version: 12.0.1
+  resolution: "@metamask/eth-json-rpc-middleware@npm:12.0.1"
+  dependencies:
+    "@metamask/eth-json-rpc-provider": ^2.1.0
+    "@metamask/eth-sig-util": ^7.0.0
+    "@metamask/json-rpc-engine": ^7.1.1
+    "@metamask/rpc-errors": ^6.0.0
+    "@metamask/utils": ^8.1.0
+    eth-block-tracker: ^8.0.0
+    klona: ^2.0.6
+    pify: ^5.0.0
+    safe-stable-stringify: ^2.4.3
+  checksum: 27d7ef46bad5b9db8e5a4591c6646ffd8df974ab841e82d8c446e0458de1f2d66a86eb5bf82b3db3029065edfa7e98ec8c88a79bf4e799f131703dfc3cc9675d
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-provider@npm:^2.1.0, @metamask/eth-json-rpc-provider@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@metamask/eth-json-rpc-provider@npm:2.2.0"
+  dependencies:
+    "@metamask/json-rpc-engine": ^7.1.0
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.1.0
+  checksum: da725fa51e8bfe0b904520b8223aed209fc54605edf1ab5ae6091a460694fd4aad5046f3ae88e8df3741079507dc0e6f2e2c85f1feee8a98506c4f550ea07549
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-query@npm:^3.0.1":
   version: 3.0.1
   resolution: "@metamask/eth-query@npm:3.0.1"
@@ -1020,6 +1036,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-sig-util@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@metamask/eth-sig-util@npm:7.0.0"
+  dependencies:
+    "@ethereumjs/util": ^8.1.0
+    "@metamask/abi-utils": ^2.0.2
+    "@metamask/utils": ^8.1.0
+    ethereum-cryptography: ^2.1.2
+    ethjs-util: ^0.1.6
+    tweetnacl: ^1.0.3
+    tweetnacl-util: ^0.15.1
+  checksum: bcb6bd23333e0b4dcb49f8772483dcb4c27e75405a2b111f1eafe0b341b221cf86ba4843e91c567d8836e80b6049d8e2f89c6766c62bbd256533e0f256f6d846
+  languageName: node
+  linkType: hard
+
+"@metamask/json-rpc-engine@npm:^7.1.0, @metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@metamask/json-rpc-engine@npm:7.2.0"
+  dependencies:
+    "@metamask/rpc-errors": ^6.0.0
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.1.0
+  checksum: 81c366ebd7492b68a76da0fedfb3e6c92023f354e51b96dd7bcf8ec885ac40fc986587fdfb05669fabdc1339dfcf53a2de4baf6d8030eddc868897b995f3ad2b
+  languageName: node
+  linkType: hard
+
+"@metamask/network-controller@npm:^15.2.0":
+  version: 15.2.0
+  resolution: "@metamask/network-controller@npm:15.2.0"
+  dependencies:
+    "@metamask/base-controller": ^3.2.3
+    "@metamask/controller-utils": ^5.0.2
+    "@metamask/eth-json-rpc-infura": ^9.0.0
+    "@metamask/eth-json-rpc-middleware": ^12.0.1
+    "@metamask/eth-json-rpc-provider": ^2.2.0
+    "@metamask/eth-query": ^3.0.1
+    "@metamask/json-rpc-engine": ^7.2.0
+    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/swappable-obj-proxy": ^2.1.0
+    "@metamask/utils": ^8.2.0
+    async-mutex: ^0.2.6
+    eth-block-tracker: ^8.0.0
+    immer: ^9.0.6
+    uuid: ^8.3.2
+  checksum: 331937360ac503a5000cf6277159852a23ff7d5cd72155665467e170c3cf213e4970a1706d24765201434dd5c4a088fa5e029011a78b1be87de51ca7b4011a5f
+  languageName: node
+  linkType: hard
+
 "@metamask/ppom-validator@workspace:.":
   version: 0.0.0-use.local
   resolution: "@metamask/ppom-validator@workspace:."
@@ -1027,12 +1091,13 @@ __metadata:
     "@lavamoat/allow-scripts": ^2.3.1
     "@lavamoat/preinstall-always-fail": ^1.0.0
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.0.0
-    "@metamask/controller-utils": ^4.0.0
+    "@metamask/base-controller": ^3.2.1
+    "@metamask/controller-utils": ^5.0.0
     "@metamask/eslint-config": ^11.0.1
     "@metamask/eslint-config-jest": ^12.0.0
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
+    "@metamask/network-controller": ^15.2.0
     "@types/elliptic": ^6.4.14
     "@types/jest": ^28.1.6
     "@types/json-rpc-random-id": ^1.0.1
@@ -1062,40 +1127,66 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/utils@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "@metamask/utils@npm:6.2.0"
+"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/rpc-errors@npm:6.1.0"
   dependencies:
-    "@ethereumjs/tx": ^4.1.2
+    "@metamask/utils": ^8.1.0
+    fast-safe-stringify: ^2.0.6
+  checksum: 9f4821d804e2fcaa8987b0958d02c6d829b7c7db49740c811cb593f381d0c4b00dabb7f1802907f1b2f6126f7c0d83ec34219183d29650f5d24df014ac72906a
+  languageName: node
+  linkType: hard
+
+"@metamask/safe-event-emitter@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/safe-event-emitter@npm:3.0.0"
+  checksum: 8dc58a76f9f75bf2405931465fc311c68043d851e6b8ebe9f82ae339073a08a83430dba9338f8e3adc4bfc8067607125074bcafa32baee3a5157f42343dc89e5
+  languageName: node
+  linkType: hard
+
+"@metamask/swappable-obj-proxy@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@metamask/swappable-obj-proxy@npm:2.1.0"
+  checksum: b15cebee7fb189d1143d3a755a38a7d88f56f91e1277425a51f63c50c432dfb4e6e22650ef67474ae4ef2a97344231af00be6780f126c47d401a23c8a8fb3c9c
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "@metamask/utils@npm:8.2.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.2.0
     "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.3
     "@types/debug": ^4.1.7
     debug: ^4.3.4
-    semver: ^7.3.8
+    pony-cause: ^2.1.10
+    semver: ^7.5.4
     superstruct: ^1.0.3
-  checksum: 0bc675358ecc09b3bc04da613d73666295d7afa51ff6b8554801585966900b24b8545bd93b8b2e9a17db867ebe421fe884baf3558ec4ca3199fa65504f677c1b
+  checksum: 1c70c0f9c375bfa3836c15d48990dbea1c3cadfd3dd69b4867667116c09c3bdeef70a0c7027f1cdea88a9913cb846dc94812ece91be7ec32e65a62e00281b04c
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.0.0, @noble/curves@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "@noble/curves@npm:1.0.0"
+"@noble/curves@npm:1.1.0, @noble/curves@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "@noble/curves@npm:1.1.0"
   dependencies:
-    "@noble/hashes": 1.3.0
-  checksum: 6bcef44d626c640dc8961819d68dd67dffb907e3b973b7c27efe0ecdd9a5c6ce62c7b9e3dfc930c66605dced7f1ec0514d191c09a2ce98d6d52b66e3315ffa79
+    "@noble/hashes": 1.3.1
+  checksum: 2658cdd3f84f71079b4e3516c47559d22cf4b55c23ac8ee9d2b1f8e5b72916d9689e59820e0f9d9cb4a46a8423af5b56dc6bb7782405c88be06a015180508db5
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@noble/hashes@npm:1.3.0"
-  checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
-  languageName: node
-  linkType: hard
-
-"@noble/hashes@npm:^1.3.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:~1.3.0":
+"@noble/hashes@npm:1.3.1":
   version: 1.3.1
   resolution: "@noble/hashes@npm:1.3.1"
   checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.3.1, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1":
+  version: 1.3.2
+  resolution: "@noble/hashes@npm:1.3.2"
+  checksum: fe23536b436539d13f90e4b9be843cc63b1b17666a07634a2b1259dded6f490be3d050249e6af98076ea8f2ea0d56f578773c2197f2aa0eeaa5fba5bc18ba474
   languageName: node
   linkType: hard
 
@@ -1175,31 +1266,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@scure/base@npm:~1.1.0":
-  version: 1.1.1
-  resolution: "@scure/base@npm:1.1.1"
-  checksum: b4fc810b492693e7e8d0107313ac74c3646970c198bbe26d7332820886fa4f09441991023ec9aa3a2a51246b74409ab5ebae2e8ef148bbc253da79ac49130309
+"@scure/base@npm:^1.1.3, @scure/base@npm:~1.1.0":
+  version: 1.1.3
+  resolution: "@scure/base@npm:1.1.3"
+  checksum: 1606ab8a4db898cb3a1ada16c15437c3bce4e25854fadc8eb03ae93cbbbac1ed90655af4b0be3da37e12056fef11c0374499f69b9e658c9e5b7b3e06353c630c
   languageName: node
   linkType: hard
 
-"@scure/bip32@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@scure/bip32@npm:1.3.0"
+"@scure/bip32@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@scure/bip32@npm:1.3.1"
   dependencies:
-    "@noble/curves": ~1.0.0
-    "@noble/hashes": ~1.3.0
+    "@noble/curves": ~1.1.0
+    "@noble/hashes": ~1.3.1
     "@scure/base": ~1.1.0
-  checksum: 6eae997f9bdf41fe848134898960ac48e645fa10e63d579be965ca331afd0b7c1b8ebac170770d237ab4099dafc35e5a82995384510025ccf2abe669f85e8918
+  checksum: 394d65f77a40651eba21a5096da0f4233c3b50d422864751d373fcf142eeedb94a1149f9ab1dbb078086dab2d0bc27e2b1afec8321bf22d4403c7df2fea5bfe2
   languageName: node
   linkType: hard
 
-"@scure/bip39@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@scure/bip39@npm:1.2.0"
+"@scure/bip39@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@scure/bip39@npm:1.2.1"
   dependencies:
     "@noble/hashes": ~1.3.0
     "@scure/base": ~1.1.0
-  checksum: 980d761f53e63de04a9e4db840eb13bfb1bd1b664ecb04a71824c12c190f4972fd84146f3ed89b2a8e4c6bd2c17c15f8b592b7ac029e903323b0f9e2dae6916b
+  checksum: c5bd6f1328fdbeae2dcdd891825b1610225310e5e62a4942714db51066866e4f7bef242c7b06a1b9dcc8043a4a13412cf5c5df76d3b10aa9e36b82e9b6e3eeaa
   languageName: node
   linkType: hard
 
@@ -1918,6 +2009,15 @@ __metadata:
   version: 2.0.1
   resolution: "arrify@npm:2.0.1"
   checksum: 067c4c1afd182806a82e4c1cb8acee16ab8b5284fbca1ce29408e6e91281c36bb5b612f6ddfbd40a0f7a7e0c75bf2696eb94c027f6e328d6e9c52465c98e4209
+  languageName: node
+  linkType: hard
+
+"async-mutex@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "async-mutex@npm:0.2.6"
+  dependencies:
+    tslib: ^2.0.0
+  checksum: f50102e0c57f6a958528cff7dff13da070897f17107b42274417a7248905b927b6e51c3387f8aed1f5cd6005b0e692d64a83a0789be602e4e7e7da4afe08b889
   languageName: node
   linkType: hard
 
@@ -3156,6 +3256,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eth-block-tracker@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "eth-block-tracker@npm:8.1.0"
+  dependencies:
+    "@metamask/eth-json-rpc-provider": ^2.1.0
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.1.0
+    json-rpc-random-id: ^1.0.1
+    pify: ^5.0.0
+  checksum: a7e1e8462995d2924a2daa3224539c120df6c07a26d68522f4338ca23189d4195545e6251b8e64f79dc99a685a8124efd496e25f7ee201dc273d92e3d9e90aad
+  languageName: node
+  linkType: hard
+
 "eth-ens-namehash@npm:^2.0.8":
   version: 2.0.8
   resolution: "eth-ens-namehash@npm:2.0.8"
@@ -3163,15 +3276,6 @@ __metadata:
     idna-uts46-hx: ^2.3.1
     js-sha3: ^0.5.7
   checksum: 40ce4aeedaa4e7eb4485c8d8857457ecc46a4652396981d21b7e3a5f922d5beff63c71cb4b283c935293e530eba50b329d9248be3c433949c6bc40c850c202a3
-  languageName: node
-  linkType: hard
-
-"eth-rpc-errors@npm:^4.0.2":
-  version: 4.0.3
-  resolution: "eth-rpc-errors@npm:4.0.3"
-  dependencies:
-    fast-safe-stringify: ^2.0.6
-  checksum: 5fa31d1a10fdb340733b9a55e38e7687222c501052ca20743cef4d0c911a9bbcc0cad54aa6bf3e4b428604c071ff519803060e1cbc79ddb7c9257c11d407d32a
   languageName: node
   linkType: hard
 
@@ -3198,15 +3302,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethereum-cryptography@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "ethereum-cryptography@npm:2.0.0"
+"ethereum-cryptography@npm:^2.0.0, ethereum-cryptography@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "ethereum-cryptography@npm:2.1.2"
   dependencies:
-    "@noble/curves": 1.0.0
-    "@noble/hashes": 1.3.0
-    "@scure/bip32": 1.3.0
-    "@scure/bip39": 1.2.0
-  checksum: 958f8aab2d1b32aa759fb27a27877b3647410e8bb9aca7d65d1d477db4864cf7fc46b918eb52a1e246c25e98ee0a35a632c88b496aeaefa13469ee767a76c8db
+    "@noble/curves": 1.1.0
+    "@noble/hashes": 1.3.1
+    "@scure/bip32": 1.3.1
+    "@scure/bip39": 1.2.1
+  checksum: 2e8f7b8cc90232ae838ab6a8167708e8362621404d26e79b5d9e762c7b53d699f7520aff358d9254de658fcd54d2d0af168ff909943259ed27dc4cef2736410c
   languageName: node
   linkType: hard
 
@@ -3230,6 +3334,16 @@ __metadata:
     bn.js: 4.11.6
     number-to-bn: 1.7.0
   checksum: df6b4752ff7461a59a20219f4b1684c631ea601241c39660e3f6c6bd63c950189723841c22b3c6c0ebeb3c9fc99e0e803e3c613101206132603705fcbcf4def5
+  languageName: node
+  linkType: hard
+
+"ethjs-util@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "ethjs-util@npm:0.1.6"
+  dependencies:
+    is-hex-prefixed: 1.0.0
+    strip-hex-prefix: 1.0.0
+  checksum: 1f42959e78ec6f49889c49c8a98639e06f52a15966387dd39faf2930db48663d026efb7db2702dcffe7f2a99c4a0144b7ce784efdbf733f4077aae95de76d65f
   languageName: node
   linkType: hard
 
@@ -4750,6 +4864,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"klona@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "klona@npm:2.0.6"
+  checksum: ac9ee3732e42b96feb67faae4d27cf49494e8a3bf3fa7115ce242fe04786788e0aff4741a07a45a2462e2079aa983d73d38519c85d65b70ef11447bbc3c58ce7
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -5161,6 +5282,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:^2.6.7":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
+  languageName: node
+  linkType: hard
+
 "node-gyp-build@npm:^4.2.0":
   version: 4.6.0
   resolution: "node-gyp-build@npm:4.6.0"
@@ -5497,6 +5632,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pify@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pify@npm:5.0.0"
+  checksum: 443e3e198ad6bfa8c0c533764cf75c9d5bc976387a163792fb553ffe6ce923887cf14eebf5aea9b7caa8eab930da8c33612990ae85bd8c2bc18bedb9eae94ecb
+  languageName: node
+  linkType: hard
+
 "pirates@npm:^4.0.4":
   version: 4.0.5
   resolution: "pirates@npm:4.0.5"
@@ -5519,6 +5661,13 @@ __metadata:
   dependencies:
     semver-compare: ^1.0.0
   checksum: d87c41581a2a022fbe25965a97006238cd9b8cbbf49b39f78d262548149a9d30bd2bdf35fec3d810e0001e630cd46ef13c7e19c389dea8de7e64db271a2381bb
+  languageName: node
+  linkType: hard
+
+"pony-cause@npm:^2.1.10":
+  version: 2.1.10
+  resolution: "pony-cause@npm:2.1.10"
+  checksum: 8b61378f213e61056312dc274a1c79980154e9d864f6ad86e0c8b91a50d3ce900d430995ee24147c9f3caa440dfe7d51c274b488d7f033b65b206522536d7217
   languageName: node
   linkType: hard
 
@@ -5859,6 +6008,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-stable-stringify@npm:^2.4.3":
+  version: 2.4.3
+  resolution: "safe-stable-stringify@npm:2.4.3"
+  checksum: 3aeb64449706ee1f5ad2459fc99648b131d48e7a1fbb608d7c628020177512dc9d94108a5cb61bbc953985d313d0afea6566d243237743e02870490afef04b43
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -5915,14 +6071,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8":
-  version: 7.3.8
-  resolution: "semver@npm:7.3.8"
+"semver@npm:7.x, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 
@@ -6372,6 +6528,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
+  languageName: node
+  linkType: hard
+
 "ts-jest@npm:^28.0.7":
   version: 28.0.8
   resolution: "ts-jest@npm:28.0.8"
@@ -6462,6 +6625,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.0.0":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
+  languageName: node
+  linkType: hard
+
 "tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
@@ -6470,6 +6640,20 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
+  languageName: node
+  linkType: hard
+
+"tweetnacl-util@npm:^0.15.1":
+  version: 0.15.1
+  resolution: "tweetnacl-util@npm:0.15.1"
+  checksum: ae6aa8a52cdd21a95103a4cc10657d6a2040b36c7a6da7b9d3ab811c6750a2d5db77e8c36969e75fdee11f511aa2b91c552496c6e8e989b6e490e54aca2864fc
+  languageName: node
+  linkType: hard
+
+"tweetnacl@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "tweetnacl@npm:1.0.3"
+  checksum: e4a57cac188f0c53f24c7a33279e223618a2bfb5fea426231991652a13247bea06b081fd745d71291fcae0f4428d29beba1b984b1f1ce6f66b06a6d1ab90645c
   languageName: node
   linkType: hard
 
@@ -6599,6 +6783,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
 "v8-compile-cache-lib@npm:^3.0.0":
   version: 3.0.0
   resolution: "v8-compile-cache-lib@npm:3.0.0"
@@ -6637,6 +6830,23 @@ __metadata:
   dependencies:
     makeerror: 1.0.12
   checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: ~0.0.3
+    webidl-conversions: ^3.0.0
+  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* `onNetworkChange` now updates `state.chainStatus` for `networkState.providerConfig.chaindId` and each network configuration in `networkState.networkConfigurations`
* `usePPOM()` now accepts an optional `networkClientId` as the last param which will be used to override the default chainId and provider
* PPOM Messenger now needs permission to call `NetworkController:getNetworkClientById`