### PR TITLE
PPOM instance to stay when user switch the network

### DIFF
--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -1,5 +1,4 @@
 import {
-  PPOMClass,
   VERSION_INFO,
   buildDummyResponse,
   buildFetchSpy,

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -369,59 +369,6 @@ describe('PPOMController', () => {
         'Aborting validation as not all files could not be downloaded for the network with chainId: 0x1',
       );
     });
-
-    it('should reset PPOM when network is switched', async () => {
-      buildFetchSpy();
-      let callBack: any;
-      const freeMock = jest.fn();
-      ppomController = buildPPOMController({
-        storageBackend: buildStorageBackend({
-          read: async (): Promise<any> => {
-            throw new Error('not found');
-          },
-        }),
-        onNetworkChange: (func: any) => {
-          callBack = func;
-        },
-        chainId: '0x2',
-        ppomProvider: {
-          ppomInit: () => undefined,
-          PPOM: new PPOMClass(undefined, freeMock),
-        },
-      });
-      callBack({ providerConfig: { chainId: '0x1' } });
-      await flushPromises();
-      jest.runOnlyPendingTimers();
-      await flushPromises();
-      callBack({ providerConfig: { chainId: '0x2' } });
-      await flushPromises();
-      expect(freeMock).toHaveBeenCalledTimes(1);
-    });
-
-    it('should not throw error if PPOM init on network changs fails', async () => {
-      buildFetchSpy();
-      let callBack: any;
-      const newMock = jest.fn().mockImplementation(() => {
-        throw Error('test');
-      });
-      ppomController = buildPPOMController({
-        onNetworkChange: (func: any) => {
-          callBack = func;
-        },
-        chainId: '0x1',
-        ppomProvider: {
-          ppomInit: () => undefined,
-          PPOM: new PPOMClass(newMock),
-        },
-      });
-      callBack({ providerConfig: { chainId: '0x2' } });
-      await flushPromises();
-      jest.runOnlyPendingTimers();
-      await flushPromises();
-      callBack({ providerConfig: { chainId: '0x1' } });
-      await flushPromises();
-      expect(newMock).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('updatePPOM', () => {
@@ -477,25 +424,6 @@ describe('PPOMController', () => {
       await flushPromises();
       // 2 additional call this time is to version info HEAD
       expect(spy).toHaveBeenCalledTimes(9);
-    });
-
-    it('should set dataFetched to true for supported chainIds in chainStatus', async () => {
-      buildFetchSpy();
-      let callBack: any;
-      ppomController = buildPPOMController({
-        onNetworkChange: (func: any) => {
-          callBack = func;
-        },
-      });
-      jest.runOnlyPendingTimers();
-      callBack({ providerConfig: { chainId: '0x2' } });
-      await ppomController.updatePPOM();
-      jest.runOnlyPendingTimers();
-      await flushPromises();
-      const chainIdData1 = ppomController.state.chainStatus['0x1'];
-      const chainIdData2 = ppomController.state.chainStatus['0x2'];
-      expect(chainIdData1.dataFetched).toBe(true);
-      expect(chainIdData2.dataFetched).toBe(false);
     });
 
     it('should get files for only supported chains in chainStatus', async () => {
@@ -566,20 +494,21 @@ describe('PPOMController', () => {
       buildFetchSpy();
       let callBack: any;
       ppomController = buildPPOMController({
+        chainId: '0x2',
         onNetworkChange: (func: any) => {
           callBack = func;
         },
       });
       jest.runOnlyPendingTimers();
       await flushPromises();
-      const chainIdData1 = ppomController.state.chainStatus['0x1'];
+      const chainIdData1 = ppomController.state.chainStatus['0x2'];
       expect(chainIdData1).toBeDefined();
-      callBack({ providerConfig: { chainId: '0x2' } });
       callBack({ providerConfig: { chainId: '0x3' } });
+      callBack({ providerConfig: { chainId: '0x4' } });
       jest.advanceTimersByTime(NETWORK_CACHE_DURATION);
       jest.runOnlyPendingTimers();
       await flushPromises();
-      const chainIdData2 = ppomController.state.chainStatus['0x1'];
+      const chainIdData2 = ppomController.state.chainStatus['0x2'];
       expect(chainIdData2).toBeUndefined();
     });
 
@@ -598,48 +527,6 @@ describe('PPOMController', () => {
       jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
       await flushPromises();
       expect(spy).toHaveBeenCalledTimes(6);
-    });
-
-    it('should re-init ppom when new set of files are fetched', async () => {
-      buildFetchSpy();
-      const newMock = jest.fn();
-      ppomController = buildPPOMController({
-        ppomProvider: {
-          ppomInit: () => undefined,
-          PPOM: new PPOMClass(newMock),
-        },
-        fileFetchScheduleDuration: 0,
-      });
-      await flushPromises();
-      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
-      await flushPromises();
-      expect(newMock).toHaveBeenCalledTimes(1);
-
-      buildFetchSpy(
-        {
-          status: 200,
-          json: () => [
-            ...VERSION_INFO,
-            {
-              name: 'data2',
-              chainId: '0x1',
-              version: '1.0.3',
-              checksum:
-                '409a7f83ac6b31dc8c77e3ec18038f209bd2f545e0f4177c2e2381aa4e067b49',
-              filePath: 'data2',
-            },
-          ],
-        },
-        undefined,
-        2,
-      );
-      await flushPromises();
-
-      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
-      await flushPromises();
-      jest.advanceTimersByTime(1);
-      await flushPromises();
-      expect(newMock).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -687,6 +574,7 @@ describe('PPOMController', () => {
       buildFetchSpy();
       let callBack: any;
       ppomController = buildPPOMController({
+        chainId: '0x2',
         onNetworkChange: (func: any) => {
           callBack = func;
         },
@@ -695,49 +583,24 @@ describe('PPOMController', () => {
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(1);
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-02'));
-      callBack({ providerConfig: { chainId: '0x2' } });
+      callBack({ providerConfig: { chainId: '0x3' } });
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-05'));
       callBack({ providerConfig: { chainId: '0x5' } });
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-03'));
-      callBack({ providerConfig: { chainId: '0x3' } });
+      callBack({ providerConfig: { chainId: '0x4' } });
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-04'));
-      callBack({ providerConfig: { chainId: '0x4' } });
+      callBack({ providerConfig: { chainId: '0x6' } });
 
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(5);
 
       jest.useFakeTimers().setSystemTime(new Date('2023-01-06'));
-      callBack({ providerConfig: { chainId: '0x6' } });
+      callBack({ providerConfig: { chainId: '0x7' } });
       expect(Object.keys(ppomController.state.chainStatus)).toHaveLength(5);
 
       expect(ppomController.state.chainStatus['0x1']).toBeUndefined();
-    });
-
-    it('should reset PPOM when network is changed', async () => {
-      buildFetchSpy();
-      const freeMock = jest.fn().mockReturnValue('abc');
-      let callBack: any;
-      ppomController = buildPPOMController({
-        onNetworkChange: (func: any) => {
-          callBack = func;
-        },
-        chainId: '0x1',
-        ppomProvider: {
-          ppomInit: () => undefined,
-          PPOM: new PPOMClass(undefined, freeMock),
-        },
-      });
-
-      await flushPromises();
-      jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
-      await flushPromises();
-
-      expect(freeMock).toHaveBeenCalledTimes(0);
-      callBack({ providerConfig: { chainId: '0x2' } });
-      callBack({ providerConfig: { chainId: '0x1' } });
-      expect(freeMock).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
The PR fixes issue with mobile app being laggy when networks is switched:

1. When network is switched ppom instance is not reset
2. Mainnet is not removed from chainstatus
3. PPOM instance for mainnet is always in memory

This PR will need a reset before we can support PPOM for multichain.