### PR TITLE
Revert "Bump @metamask/base-controller from 3.2.3 to 4.0.1 (#117)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^4.0.1",
+    "@metamask/base-controller": "^3.0.0",
     "@metamask/controller-utils": "^8.0.1",
     "@metamask/network-controller": "^17.0.0",
     "await-semaphore": "^0.1.3",

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -1,5 +1,5 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseController } from '@metamask/base-controller';
+import { BaseControllerV2 } from '@metamask/base-controller';
 import { safelyExecute, timeoutFetch } from '@metamask/controller-utils';
 import type { NetworkControllerStateChangeEvent } from '@metamask/network-controller';
 import { Mutex } from 'await-semaphore';
@@ -170,7 +170,7 @@ type PPOMProvider = {
  * @property ppom - The PPOM instance
  * @property provider - The provider used to create the PPOM instance
  */
-export class PPOMController extends BaseController<
+export class PPOMController extends BaseControllerV2<
   typeof controllerName,
   PPOMState,
   PPOMControllerMessenger

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,6 +932,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/base-controller@npm:^3.0.0":
+  version: 3.2.3
+  resolution: "@metamask/base-controller@npm:3.2.3"
+  dependencies:
+    "@metamask/utils": ^8.1.0
+    immer: ^9.0.6
+  checksum: f49fcf2bf892ec25657c2d72a50b3c4f3cad59acb1b74d9fdcdf564107b8f38f73647c696aaa9699d94828b5797d8f1479dab44a2dbcda987c268b0088bb3b76
+  languageName: node
+  linkType: hard
+
 "@metamask/base-controller@npm:^4.0.1":
   version: 4.0.1
   resolution: "@metamask/base-controller@npm:4.0.1"
@@ -1122,7 +1132,7 @@ __metadata:
     "@lavamoat/allow-scripts": ^2.3.1
     "@lavamoat/preinstall-always-fail": ^1.0.0
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^4.0.1
+    "@metamask/base-controller": ^3.0.0
     "@metamask/controller-utils": ^8.0.1
     "@metamask/eslint-config": ^12.2.0
     "@metamask/eslint-config-jest": ^12.0.0


### PR DESCRIPTION
Reverting base controller update.