### PR TITLE
Reset PPOM on network change

### DIFF
--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -427,7 +427,7 @@ describe('PPOMController', () => {
       await ppomController.updatePPOM();
       jest.runOnlyPendingTimers();
       await flushPromises();
-      expect(spy).toHaveBeenCalledTimes(13);
+      expect(spy).toHaveBeenCalledTimes(9);
     });
 
     it('should not re-throw error if file write fails', async () => {
@@ -524,7 +524,7 @@ describe('PPOMController', () => {
       changeNetwork('0x1');
       jest.runOnlyPendingTimers();
       await flushPromises();
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('should not trigger file download if preference is not enabled', async () => {
@@ -588,26 +588,20 @@ describe('PPOMController', () => {
       expect(ppomController.state.chainStatus['0x1']).toBeUndefined();
     });
 
-    it('should not throw error if resetting ppom fails', async () => {
-      buildFetchSpy(undefined, undefined, 123);
-      const freeMock = jest.fn().mockImplementation(() => {
-        throw new Error('some error');
-      });
-      const { changeNetwork } = buildPPOMController({
-        ppomProvider: {
-          ppomInit: async () => {
-            return Promise.resolve('123');
-          },
-          PPOM: new PPOMClass(undefined, freeMock),
-        },
-      });
-      jest.runOnlyPendingTimers();
+    it('should not throw error if update ppom fails', async () => {
+      buildFetchSpy();
+      const { changeNetwork } = buildPPOMController({ chainId: '0x2' });
+      changeNetwork('0x1');
       await flushPromises();
-      buildFetchSpy({
-        status: 500,
-      });
       expect(async () => {
-        changeNetwork('0x1');
+        buildFetchSpy({
+          status: 500,
+          json: () => {
+            throw new Error('some error');
+          },
+        });
+        jest.runOnlyPendingTimers();
+        await flushPromises();
       }).not.toThrow();
     });
   });

--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -587,6 +587,29 @@ describe('PPOMController', () => {
 
       expect(ppomController.state.chainStatus['0x1']).toBeUndefined();
     });
+
+    it('should not throw error if resetting ppom fails', async () => {
+      buildFetchSpy(undefined, undefined, 123);
+      const freeMock = jest.fn().mockImplementation(() => {
+        throw new Error('some error');
+      });
+      const { changeNetwork } = buildPPOMController({
+        ppomProvider: {
+          ppomInit: async () => {
+            return Promise.resolve('123');
+          },
+          PPOM: new PPOMClass(undefined, freeMock),
+        },
+      });
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+      buildFetchSpy({
+        status: 500,
+      });
+      expect(async () => {
+        changeNetwork('0x1');
+      }).not.toThrow();
+    });
   });
 
   describe('onPreferencesChange', () => {

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -475,9 +475,9 @@ export class PPOMController extends BaseControllerV2<
    */
   #onNetworkChange(networkControllerState: any): void {
     const id = addHexPrefix(networkControllerState.providerConfig.chainId);
+    this.#chainId = id;
     let chainStatus = { ...this.state.chainStatus };
     const existingNetworkObject = chainStatus[id];
-    this.#chainId = id;
     chainStatus = {
       ...chainStatus,
       [id]: {
@@ -491,10 +491,9 @@ export class PPOMController extends BaseControllerV2<
       draftState.chainStatus = chainStatus;
     });
     this.#deleteOldChainIds();
-    this.#checkScheduleFileDownloadForAllChains();
-    this.#resetPPOM().catch((error: Error) => {
-      console.error(`Error in resetting ppom: ${error.message}`);
-    });
+    if (this.#networkIsSupported(id) && this.#securityAlertsEnabled) {
+      this.#setToActiveState();
+    }
   }
 
   /*
@@ -1066,8 +1065,6 @@ export class PPOMController extends BaseControllerV2<
           this.#dataUpdateDuration,
         );
       }
-    } else {
-      this.#resetToInactiveState();
     }
   }
 }

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -492,6 +492,9 @@ export class PPOMController extends BaseControllerV2<
     });
     this.#deleteOldChainIds();
     this.#checkScheduleFileDownloadForAllChains();
+    this.#resetPPOM().catch((error: Error) => {
+      console.error(`Error in resetting ppom: ${error.message}`);
+    });
   }
 
   /*


### PR DESCRIPTION
Reset PPOM on network change, this is required to support multiple networks on mobile and extension.

Fixes: MetaMask/MetaMask-planning#1922
