### PR TITLE
Delete files from storage as blockaid preference is disabled

### DIFF
--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -475,6 +475,7 @@ export class PPOMController extends BaseControllerV2<
       console.error(`Error in resetting ppom: ${error.message}`);
     });
     this.#clearDataFetchIntervals();
+    const storageMetadata = { ...this.state.storageMetadata };
     this.update((draftState) => {
       draftState.versionInfo = [];
       const newChainStatus = { ...this.state.chainStatus };
@@ -490,6 +491,9 @@ export class PPOMController extends BaseControllerV2<
       draftState.chainStatus = newChainStatus;
       draftState.storageMetadata = [];
       draftState.versionFileETag = '';
+    });
+    this.#storage.deleteAllFiles(storageMetadata).catch((error: Error) => {
+      console.error(`Error in deleting files: ${error.message}`);
     });
   }
 

--- a/src/ppom-storage.test.ts
+++ b/src/ppom-storage.test.ts
@@ -206,4 +206,36 @@ describe('PPOMStorage', () => {
       });
     });
   });
+
+  describe('deleteAllFiles', () => {
+    it('should delete all files passed to it', async () => {
+      const mockDeleteFile = jest
+        .fn()
+        .mockImplementation(async () => Promise.resolve());
+      const storageBackend = buildStorageBackend({ delete: mockDeleteFile });
+      const ppomStorage = new PPOMStorage({
+        storageBackend,
+        readMetadata: () => [simpleFileData],
+        writeMetadata: () => undefined,
+      });
+      await ppomStorage.deleteAllFiles([simpleFileData]);
+      expect(mockDeleteFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw error if delete fails', async () => {
+      const mockDeleteFile = jest
+        .fn()
+        .mockImplementation(async () =>
+          Promise.reject(new Error('some error')),
+        );
+      const storageBackend = buildStorageBackend({ delete: mockDeleteFile });
+      const ppomStorage = new PPOMStorage({
+        storageBackend,
+        readMetadata: () => [simpleFileData],
+        writeMetadata: () => undefined,
+      });
+      await ppomStorage.deleteAllFiles([simpleFileData]);
+      expect(mockDeleteFile).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/ppom-storage.ts
+++ b/src/ppom-storage.ts
@@ -144,6 +144,22 @@ export class PPOMStorage {
   }
 
   /**
+   * Delete all files in storage.
+   *
+   * @param metadata - List of all files in storage.
+   */
+  async deleteAllFiles(metadata: FileMetadataList): Promise<void> {
+    for (const fileMetadata of metadata) {
+      const { name, chainId } = fileMetadata;
+      try {
+        await this.#storageBackend.delete({ name, chainId });
+      } catch (exp: any) {
+        console.error(`Error in deleting file: ${name}, ${chainId}`, exp);
+      }
+    }
+  }
+
+  /**
    * Read the file from the local storage.
    * 1. Check if the file exists in the local storage.
    * 2. Check if the file exists in the metadata.


### PR DESCRIPTION
Fixes: MetaMask/metamask-extension#22776
Fixes: MetaMask/metamask-mobile#8493

Clear storage as user disabled blockaid option.
