### PR TITLE
Metadata should be synced for only active networks

### DIFF
--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -900,13 +900,13 @@ export class PPOMController extends BaseControllerV2<
       // clear interval if all files are fetched
       if (!fileToBeFetchedList.length) {
         clearInterval(this.#fileScheduleInterval);
-        this.#storage
-          .syncMetadata(this.state.versionInfo)
-          .catch((exp: Error) => {
-            console.error(
-              `Error while trying to sync metadata: ${exp.message}`,
-            );
-          });
+        const activeChainIds = Object.keys(this.state.chainStatus);
+        const versionInfoRequired = this.state.versionInfo.filter(
+          ({ chainId }) => activeChainIds.includes(chainId),
+        );
+        this.#storage.syncMetadata(versionInfoRequired).catch((exp: Error) => {
+          console.error(`Error while trying to sync metadata: ${exp.message}`);
+        });
       }
     }, scheduleInterval);
   }


### PR DESCRIPTION
Fixes: MetaMask/metamask-extension#22777

Metadata should be synced for only active networks. This is to ensure that any files stored for old networks are deleted from storage.