### PR TITLE
fix: delete all files fails when blockaid preference is disabled

### DIFF
--- a/src/ppom-controller-mocked-storage.test.ts
+++ b/src/ppom-controller-mocked-storage.test.ts
@@ -1,0 +1,48 @@
+import { buildFetchSpy, buildPPOMController } from '../test/test-utils';
+import { REFRESH_TIME_INTERVAL } from './ppom-controller';
+
+jest.mock('@metamask/controller-utils', () => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    ...jest.requireActual('@metamask/controller-utils'),
+  };
+});
+
+jest.mock('./ppom-storage', () => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    ...jest.requireActual('../test/mock-ppom-storage'),
+  };
+});
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+async function flushPromises() {
+  // Wait for promises running in the non-async timer callback to complete.
+  // From https://github.com/facebook/jest/issues/2157#issuecomment-897935688
+  return new Promise(jest.requireActual('timers').setImmediate);
+}
+
+describe('PPOMController', () => {
+  describe('onPreferencesChange', () => {
+    it('should not throw error storage deleteAll fails', async () => {
+      buildFetchSpy(undefined, undefined, 123);
+      let callBack: any;
+      buildPPOMController({
+        onPreferencesChange: (func: any) => {
+          callBack = func;
+        },
+      });
+      jest.runOnlyPendingTimers();
+      await flushPromises();
+      expect(async () => {
+        callBack({ securityAlertsEnabled: false });
+        callBack({ securityAlertsEnabled: true });
+        jest.advanceTimersByTime(REFRESH_TIME_INTERVAL);
+        jest.runOnlyPendingTimers();
+        await flushPromises();
+      }).not.toThrow();
+    });
+  });
+});

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -475,7 +475,7 @@ export class PPOMController extends BaseControllerV2<
       console.error(`Error in resetting ppom: ${error.message}`);
     });
     this.#clearDataFetchIntervals();
-    const storageMetadata = { ...this.state.storageMetadata };
+    const { storageMetadata } = this.state;
     this.update((draftState) => {
       draftState.versionInfo = [];
       const newChainStatus = { ...this.state.chainStatus };

--- a/test/mock-ppom-storage.ts
+++ b/test/mock-ppom-storage.ts
@@ -1,0 +1,17 @@
+export class PPOMStorage {
+  async syncMetadata(): Promise<void> {
+    return undefined;
+  }
+
+  async deleteAllFiles(): Promise<void> {
+    throw new Error('some error');
+  }
+
+  async readFile(): Promise<void> {
+    return undefined;
+  }
+
+  async writeFile(): Promise<void> {
+    return undefined;
+  }
+}


### PR DESCRIPTION
fix: deleteAll files failing when blockaid preference is disabled