### PR TITLE
PPOM access fix

### DIFF
--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -384,7 +384,7 @@ describe('PPOMController', () => {
       expect(async () => {
         changeNetwork('0x2');
       }).not.toThrow();
-      expect(mockMutexUse).toHaveBeenCalledTimes(4);
+      expect(mockMutexUse).toHaveBeenCalledTimes(2);
     });
 
     it('should not do anything when networkChange called for same network', async () => {
@@ -397,7 +397,7 @@ describe('PPOMController', () => {
       });
 
       changeNetwork(Utils.SUPPORTED_NETWORK_CHAINIDS.MAINNET);
-      expect(mockMutexUse).toHaveBeenCalledTimes(3);
+      expect(mockMutexUse).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -464,11 +464,11 @@ describe('PPOMController', () => {
         return Promise.resolve();
       });
 
-      expect(mockMutexUse).toHaveBeenCalledTimes(3);
+      expect(mockMutexUse).toHaveBeenCalledTimes(1);
       callBack({ securityAlertsEnabled: false });
-      expect(mockMutexUse).toHaveBeenCalledTimes(4);
+      expect(mockMutexUse).toHaveBeenCalledTimes(2);
       callBack({ securityAlertsEnabled: false });
-      expect(mockMutexUse).toHaveBeenCalledTimes(4);
+      expect(mockMutexUse).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
Fixes: MetaMask/metamask-extension#23174
Fixes: MetaMask/metamask-extension#23295

There is a error repeatedly occurring when validation is done after switching network. I found that when network is switched we reset PPOM but its async process. In case next transaction is received before PPOM is cleared this can result in error.

I added code to get new instance of PPOM to mutex lock to ensure that instance of PPOM is not changes while validation is done.