### PR TITLE
fix: treat all 2XX or 3XX HTTP response codes as success

### DIFF
--- a/src/ppom-controller.test.ts
+++ b/src/ppom-controller.test.ts
@@ -106,7 +106,6 @@ describe('PPOMController', () => {
           ],
         },
         undefined,
-        123,
       );
       const { ppomController } = buildPPOMController({
         fileFetchScheduleDuration: 0,
@@ -116,7 +115,7 @@ describe('PPOMController', () => {
         expect(ppom).toBeDefined();
         return Promise.resolve();
       });
-      expect(spy).toHaveBeenCalledTimes(4);
+      expect(spy).toHaveBeenCalledTimes(3);
     });
 
     it('should pass instance of provider to ppom to enable it to send JSON RPC request on it', async () => {
@@ -255,7 +254,7 @@ describe('PPOMController', () => {
     });
 
     it('should fail if local storage files are corrupted and CDN also not return file', async () => {
-      buildFetchSpy(undefined, undefined, 123);
+      buildFetchSpy();
       let callBack: any;
       const { ppomController } = buildPPOMController({
         storageBackend: buildStorageBackend({
@@ -274,13 +273,9 @@ describe('PPOMController', () => {
       });
       callBack({ securityAlertsEnabled: false });
       callBack({ securityAlertsEnabled: true });
-      buildFetchSpy(
-        undefined,
-        {
-          status: 500,
-        },
-        456,
-      );
+      buildFetchSpy(undefined, {
+        status: 500,
+      });
 
       await expect(async () => {
         await ppomController.usePPOM(async () => {
@@ -306,20 +301,23 @@ describe('PPOMController', () => {
       });
     });
 
-    it('should not get files if ETag of version info file is not changed', async () => {
-      const spy = buildFetchSpy(undefined, undefined, 1);
+    it('should not get files if cached response is obtained for version info file', async () => {
+      const spy = buildFetchSpy({
+        status: 304,
+        json: () => VERSION_INFO,
+      });
       const { changeNetwork, ppomController } = buildPPOMController();
       await ppomController.usePPOM(async () => {
         return Promise.resolve();
       });
-      expect(spy).toHaveBeenCalledTimes(4);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       changeNetwork('0x2');
       changeNetwork(Utils.SUPPORTED_NETWORK_CHAINIDS.MAINNET);
       await ppomController.usePPOM(async () => {
         return Promise.resolve();
       });
-      expect(spy).toHaveBeenCalledTimes(5);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
 
     it('should re-initantiate PPOM instance if there are new files', async () => {

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -575,6 +575,7 @@ export class PPOMController extends BaseControllerV2<
     options: Record<string, unknown> = {},
     method = 'GET',
   ): Promise<any> {
+    let cached = false;
     const response = await safelyExecute(
       async () =>
         timeoutFetch(
@@ -589,35 +590,13 @@ export class PPOMController extends BaseControllerV2<
         ),
       true,
     );
-    if (response?.status !== 200) {
+    if (response?.status === 304) {
+      cached = true;
+    }
+    if (!response?.status || response?.status < 200 || response?.status > 399) {
       throw new Error(`Failed to fetch file with url: ${url}`);
     }
-    return response;
-  }
-
-  /*
-   * Function sends a HEAD request to version info file and compares the ETag to the one saved in controller state.
-   * If ETag is not changed we can be sure that there is not change in files and we do not need to fetch data again.
-   */
-  async #checkIfVersionInfoETagChanged(url: string): Promise<boolean> {
-    const headResponse = await this.#getAPIResponse(
-      url,
-      {
-        headers: versionInfoFileHeaders,
-      },
-      'HEAD',
-    );
-
-    const { versionFileETag } = this.state;
-    if (headResponse.headers.get('ETag') === versionFileETag) {
-      return false;
-    }
-
-    this.update((draftState) => {
-      draftState.versionFileETag = headResponse.headers.get('ETag');
-    });
-
-    return true;
+    return { cached, response };
   }
 
   /*
@@ -627,14 +606,14 @@ export class PPOMController extends BaseControllerV2<
     const url = constructURLHref(this.#cdnBaseUrl, PPOM_VERSION_FILE_NAME);
 
     // If ETag is same it is not required to fetch data files again
-    const eTagChanged = await this.#checkIfVersionInfoETagChanged(url);
-    if (!eTagChanged && this.state.versionInfo?.length) {
+    const { cached, response } = await this.#getAPIResponse(url, {
+      headers: versionInfoFileHeaders,
+    });
+
+    if (cached && this.state.versionInfo?.length) {
       return undefined;
     }
 
-    const response = await this.#getAPIResponse(url, {
-      headers: versionInfoFileHeaders,
-    });
     return response.json();
   }
 
@@ -642,7 +621,7 @@ export class PPOMController extends BaseControllerV2<
    * Fetch the blob file from the PPOM cdn.
    */
   async #fetchBlob(url: string): Promise<ArrayBuffer> {
-    const response = await this.#getAPIResponse(url);
+    const { response } = await this.#getAPIResponse(url);
     return await response.arrayBuffer();
   }
 

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -114,18 +114,12 @@ export const buildFetchSpy = (
     status: 200,
     arrayBuffer: () => new ArrayBuffer(123),
   },
-  eTag?: number,
 ) => {
   return jest
     .spyOn(ControllerUtils, 'timeoutFetch' as any)
     .mockImplementation((url: any) => {
       if (url === PPOM_VERSION_PATH) {
-        return {
-          headers: {
-            get: () => eTag ?? Math.round(Math.random() * 100),
-          },
-          ...versionData,
-        };
+        return versionData;
       }
       return blobData;
     });


### PR DESCRIPTION
Treat all 2XX or 3XX HTTP response codes as success

Fixes: https://github.com/orgs/MetaMask/projects/78/views/1?pane=issue&itemId=66197718