### PR TITLE
Fix NetworkController event subscription

### DIFF
--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -3,7 +3,7 @@ import { BaseControllerV2 } from '@metamask/base-controller';
 import { safelyExecute, timeoutFetch } from '@metamask/controller-utils';
 import type {
   NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerStateChangeEvent,
+  NetworkControllerNetworkDidChangeEvent,
   NetworkState,
   Provider,
 } from '@metamask/network-controller';
@@ -129,7 +129,7 @@ export type UsePPOM = {
 
 export type PPOMControllerActions = UsePPOM;
 
-export type AllowedEvents = NetworkControllerStateChangeEvent;
+export type AllowedEvents = NetworkControllerNetworkDidChangeEvent;
 
 export type AllowedActions = NetworkControllerGetNetworkClientByIdAction;
 
@@ -432,7 +432,7 @@ export class PPOMController extends BaseControllerV2<
   #subscribeMessageEvents(): void {
     const onNetworkChange = this.#onNetworkChange.bind(this);
     this.messagingSystem.subscribe(
-      'NetworkController:stateChange',
+      'NetworkController:networkDidChange',
       onNetworkChange,
     );
   }

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -186,7 +186,7 @@ export const buildPPOMController = (options?: any) => {
   const messenger = controllerMessenger.getRestricted({
     name: 'PPOMController',
     allowedActions: ['NetworkController:getNetworkClientById'],
-    allowedEvents: ['NetworkController:stateChange'],
+    allowedEvents: ['NetworkController:networkDidChange'],
   });
   const mockGetNetworkClientById = jest.fn();
   controllerMessenger.registerActionHandler(
@@ -218,13 +218,9 @@ export const buildPPOMController = (options?: any) => {
   }: {
     selectedNetworkClientId: NetworkClientId;
   }) => {
-    controllerMessenger.publish(
-      'NetworkController:stateChange',
-      {
-        selectedNetworkClientId,
-      } as NetworkState,
-      [],
-    );
+    controllerMessenger.publish('NetworkController:networkDidChange', {
+      selectedNetworkClientId,
+    } as NetworkState);
   };
   return {
     changeNetwork,


### PR DESCRIPTION

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
Subscribe to the `networkDidChange` event of `NetworkController` instead of the `stateChange` event.

Fixes #191 