### PR TITLE
Fix outdated, incomplete `PPOMController{,Messenger}` API

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^3.0.0",
+    "@metamask/base-controller": "^6.0.2",
     "@metamask/controller-utils": "^8.0.1",
     "@metamask/network-controller": "^20.0.0",
     "@metamask/rpc-errors": "^6.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ export type {
   PPOMState,
   UsePPOM,
   PPOMControllerActions,
+  PPOMControllerEvents,
+  PPOMControllerGetStateAction,
+  PPOMControllerStateChangeEvent,
   PPOMControllerMessenger,
 } from './ppom-controller';
 export { NETWORK_CACHE_DURATION, PPOMController } from './ppom-controller';

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -1,4 +1,8 @@
-import type { ControllerGetStateAction, ControllerStateChangeEvent, RestrictedControllerMessenger } from '@metamask/base-controller';
+import type {
+  ControllerGetStateAction,
+  ControllerStateChangeEvent,
+  RestrictedControllerMessenger,
+} from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import { safelyExecute, timeoutFetch } from '@metamask/controller-utils';
 import type {
@@ -127,11 +131,17 @@ export type UsePPOM = {
   handler: (callback: (ppom: PPOM) => Promise<unknown>) => Promise<unknown>;
 };
 
-export type PPOMControllerGetStateAction = ControllerGetStateAction<typeof controllerName, PPOMState>;
+export type PPOMControllerGetStateAction = ControllerGetStateAction<
+  typeof controllerName,
+  PPOMState
+>;
 
 export type PPOMControllerActions = PPOMControllerGetStateAction | UsePPOM;
 
-export type PPOMControllerStateChangeEvent = ControllerStateChangeEvent<typeof controllerName, PPOMState>;
+export type PPOMControllerStateChangeEvent = ControllerStateChangeEvent<
+  typeof controllerName,
+  PPOMState
+>;
 
 export type PPOMControllerEvents = PPOMControllerStateChangeEvent;
 

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -1,5 +1,5 @@
 import type { RestrictedControllerMessenger } from '@metamask/base-controller';
-import { BaseControllerV2 } from '@metamask/base-controller';
+import { BaseController } from '@metamask/base-controller';
 import { safelyExecute, timeoutFetch } from '@metamask/controller-utils';
 import type {
   NetworkControllerGetNetworkClientByIdAction,
@@ -158,7 +158,7 @@ type PPOMProvider = {
  * @property ppom - The PPOM instance
  * @property provider - The provider used to create the PPOM instance
  */
-export class PPOMController extends BaseControllerV2<
+export class PPOMController extends BaseController<
   typeof controllerName,
   PPOMState,
   PPOMControllerMessenger

--- a/src/ppom-controller.ts
+++ b/src/ppom-controller.ts
@@ -1,4 +1,4 @@
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type { ControllerGetStateAction, ControllerStateChangeEvent, RestrictedControllerMessenger } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import { safelyExecute, timeoutFetch } from '@metamask/controller-utils';
 import type {
@@ -127,7 +127,13 @@ export type UsePPOM = {
   handler: (callback: (ppom: PPOM) => Promise<unknown>) => Promise<unknown>;
 };
 
-export type PPOMControllerActions = UsePPOM;
+export type PPOMControllerGetStateAction = ControllerGetStateAction<typeof controllerName, PPOMState>;
+
+export type PPOMControllerActions = PPOMControllerGetStateAction | UsePPOM;
+
+export type PPOMControllerStateChangeEvent = ControllerStateChangeEvent<typeof controllerName, PPOMState>;
+
+export type PPOMControllerEvents = PPOMControllerStateChangeEvent;
 
 export type AllowedEvents = NetworkControllerNetworkDidChangeEvent;
 
@@ -136,7 +142,7 @@ export type AllowedActions = NetworkControllerGetNetworkClientByIdAction;
 export type PPOMControllerMessenger = RestrictedControllerMessenger<
   typeof controllerName,
   PPOMControllerActions | AllowedActions,
-  AllowedEvents,
+  PPOMControllerEvents | AllowedEvents,
   AllowedActions['type'],
   AllowedEvents['type']
 >;

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -9,8 +9,9 @@ import type {
   AllowedActions,
   AllowedEvents,
   PPOMControllerActions,
+  PPOMControllerEvents,
 } from '../src/ppom-controller';
-import { PPOMController, PPOMControllerEvents } from '../src/ppom-controller';
+import { PPOMController } from '../src/ppom-controller';
 import type { StorageKey } from '../src/ppom-storage';
 import { SUPPORTED_NETWORK_CHAINIDS } from '../src/util';
 

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -10,7 +10,7 @@ import type {
   AllowedEvents,
   PPOMControllerActions,
 } from '../src/ppom-controller';
-import { PPOMController } from '../src/ppom-controller';
+import { PPOMController, PPOMControllerEvents } from '../src/ppom-controller';
 import type { StorageKey } from '../src/ppom-storage';
 import { SUPPORTED_NETWORK_CHAINIDS } from '../src/util';
 
@@ -181,7 +181,7 @@ export class PPOMClass {
 export const buildPPOMController = (options?: any) => {
   const controllerMessenger: ControllerMessenger<
     PPOMControllerActions | AllowedActions,
-    AllowedEvents
+    PPOMControllerEvents | AllowedEvents
   > = new ControllerMessenger();
   const messenger = controllerMessenger.getRestricted({
     name: 'PPOMController',

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,17 +953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/base-controller@npm:6.0.0"
-  dependencies:
-    "@metamask/utils": ^8.3.0
-    immer: ^9.0.6
-  checksum: ff5c4acedc698e2477f1d719f64363d8763b21836dcea4675214c078457cd47dde068aa336b249663f3c7fb3c0f536ce420870811e00ca3a410646740a9f5934
-  languageName: node
-  linkType: hard
-
-"@metamask/base-controller@npm:^6.0.2":
+"@metamask/base-controller@npm:^6.0.0, @metamask/base-controller@npm:^6.0.2":
   version: 6.0.2
   resolution: "@metamask/base-controller@npm:6.0.2"
   dependencies:
@@ -1340,24 +1330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "@metamask/utils@npm:9.0.0"
-  dependencies:
-    "@ethereumjs/tx": ^4.2.0
-    "@metamask/superstruct": ^3.1.0
-    "@noble/hashes": ^1.3.1
-    "@scure/base": ^1.1.3
-    "@types/debug": ^4.1.7
-    debug: ^4.3.4
-    pony-cause: ^2.1.10
-    semver: ^7.5.4
-    uuid: ^9.0.1
-  checksum: 5dcb9d47c4768c33d451cc74c83207726c68b1340be1d091ca44105564f0ba0703026d357de7996de4459ac41cd420a0eb1f06db32f5ebbeeee581393f45fd44
-  languageName: node
-  linkType: hard
-
-"@metamask/utils@npm:^9.1.0":
+"@metamask/utils@npm:^9.0.0, @metamask/utils@npm:^9.1.0":
   version: 9.1.0
   resolution: "@metamask/utils@npm:9.1.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,16 +953,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^3.0.0":
-  version: 3.2.3
-  resolution: "@metamask/base-controller@npm:3.2.3"
-  dependencies:
-    "@metamask/utils": ^8.1.0
-    immer: ^9.0.6
-  checksum: f49fcf2bf892ec25657c2d72a50b3c4f3cad59acb1b74d9fdcdf564107b8f38f73647c696aaa9699d94828b5797d8f1479dab44a2dbcda987c268b0088bb3b76
-  languageName: node
-  linkType: hard
-
 "@metamask/base-controller@npm:^6.0.0":
   version: 6.0.0
   resolution: "@metamask/base-controller@npm:6.0.0"
@@ -970,6 +960,16 @@ __metadata:
     "@metamask/utils": ^8.3.0
     immer: ^9.0.6
   checksum: ff5c4acedc698e2477f1d719f64363d8763b21836dcea4675214c078457cd47dde068aa336b249663f3c7fb3c0f536ce420870811e00ca3a410646740a9f5934
+  languageName: node
+  linkType: hard
+
+"@metamask/base-controller@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@metamask/base-controller@npm:6.0.2"
+  dependencies:
+    "@metamask/utils": ^9.1.0
+    immer: ^9.0.6
+  checksum: 2cdd0310850d7a5ead05248b79ba94bbaee368ea1a99c999ff38e2d16630a7f12d2e4c781d0fe1d7b349f8a0b3651a831ceccd03b376cb7cc451154867fd5668
   languageName: node
   linkType: hard
 
@@ -1252,7 +1252,7 @@ __metadata:
     "@lavamoat/allow-scripts": ^2.3.1
     "@lavamoat/preinstall-always-fail": ^1.0.0
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": ^3.0.0
+    "@metamask/base-controller": ^6.0.2
     "@metamask/controller-utils": ^8.0.1
     "@metamask/eslint-config": ^12.2.0
     "@metamask/eslint-config-jest": ^12.0.0
@@ -1354,6 +1354,23 @@ __metadata:
     semver: ^7.5.4
     uuid: ^9.0.1
   checksum: 5dcb9d47c4768c33d451cc74c83207726c68b1340be1d091ca44105564f0ba0703026d357de7996de4459ac41cd420a0eb1f06db32f5ebbeeee581393f45fd44
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@metamask/utils@npm:9.1.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.2.0
+    "@metamask/superstruct": ^3.1.0
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.3
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    pony-cause: ^2.1.10
+    semver: ^7.5.4
+    uuid: ^9.0.1
+  checksum: 01f2c71a8f06158d5335bfe96bfd2f3aa39ec6b2323c5d0ff1d3136071a3e8ff7c1804d640ba1d4e07f96f3e68a95ff7729ddfcd34b373e5fefd86d6ef12d034
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Fixes outdated `@metamask/base-controller` usage which causes version mismatch errors downstream.
```ts
Type 'RestrictedControllerMessenger<"PPOMController", never, NetworkControllerStateChangeEvent | NetworkControllerStateChangeEvent, never, "NetworkController:stateChange">' is missing the following properties from type 'RestrictedControllerMessenger<"PPOMController", UsePPOM, NetworkControllerStateChangeEvent, never, "NetworkController:stateChange">': controllerMessenger, controllerName, allowedActions, allowedEventsts(2739)
```
- Fixes incorrect implementation of `BaseController` and `RestrictedControllerMessenger` APIs which causes downstream errors.
```ts
Type '"PPOMController:stateChange"' is not assignable to type '"SnapController:snapBlocked" | "SnapController:snapInstalled" | "SnapController:snapUninstalled" | "SnapController:snapInstallStarted" | "SnapController:snapInstallFailed" | ... 30 more ... | "TokensController:stateChange"'. Did you mean '"SnapController:stateChange"'?ts(2820)
```
> e.g. https://github.com/MetaMask/metamask-mobile/pull/10441/files#diff-1a656ef42f595bb9c6c1251b29808fd70d31da7a3e1a6e9be85574ad866dc1b0R1499-R1500

## Changelog

```md
## Added

- Add and export types `PPOMControllerGetStateAction`, `PPOMControllerStateChangeEvent`, `PPOMControllerEvents` ([#193](https://github.com/MetaMask/ppom-validator/pull/193))

## Changed

- **BREAKING:** Bump `@metamask/base-controller` from `^3.0.0` to `^6.0.2` ([#193](https://github.com/MetaMask/ppom-validator/pull/193))
- `PPOMControllerMessenger` must allow `PPOMController:getState` action and `PPOMController:stateChange` event  ([#193](https://github.com/MetaMask/ppom-validator/pull/193))
  - Widen `PPOMControllerActions` to include `PPOMControllerGetStateAction`.
```

## References

- Closes https://github.com/MetaMask/ppom-validator/issues/194